### PR TITLE
Update release build to patch electron version

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -34,6 +34,19 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - uses: nrwl/nx-set-shas@v4
       - run: pnpm version ${{ github.event.inputs.tagVersion }}  --no-git-tag-version
+      - name: Patch electron app version
+        shell: bash
+        env:
+          TAG_VERSION: ${{ github.event.inputs.tagVersion }}
+        run: |
+          node - <<'EOF'
+          const fs = require('fs');
+          const path = 'apps/servicebus-browser-app/src/app/constants.ts';
+          const version = process.env.TAG_VERSION;
+          const content = fs.readFileSync(path, 'utf8');
+          const updated = content.replace(/export const currentVersion = '.*';/, `export const currentVersion = '${version}';`);
+          fs.writeFileSync(path, updated);
+          EOF
       - run: pnpm exec nx run-many -t build --configuration=production
       - run: pnpm exec nx run servicebus-browser-app:make --extraMetadata.version=${{ github.event.inputs.tagVersion }}
       - name: Publish release as artifect
@@ -61,6 +74,19 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - uses: nrwl/nx-set-shas@v4
       - run: pnpm version ${{ github.event.inputs.tagVersion }} --no-git-tag-version
+      - name: Patch electron app version
+        shell: bash
+        env:
+          TAG_VERSION: ${{ github.event.inputs.tagVersion }}
+        run: |
+          node - <<'EOF'
+          const fs = require('fs');
+          const path = 'apps/servicebus-browser-app/src/app/constants.ts';
+          const version = process.env.TAG_VERSION;
+          const content = fs.readFileSync(path, 'utf8');
+          const updated = content.replace(/export const currentVersion = '.*';/, `export const currentVersion = '${version}';`);
+          fs.writeFileSync(path, updated);
+          EOF
       - run: pnpm exec nx run-many -t build --configuration=production
       - run: pnpm exec nx run servicebus-browser-app:make --extraMetadata.version=${{ github.event.inputs.tagVersion }}
       - name: Publish release as artifect
@@ -87,6 +113,19 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - uses: nrwl/nx-set-shas@v4
       - run: pnpm version ${{ github.event.inputs.tagVersion }} --no-git-tag-version
+      - name: Patch electron app version
+        shell: bash
+        env:
+          TAG_VERSION: ${{ github.event.inputs.tagVersion }}
+        run: |
+          node - <<'EOF'
+          const fs = require('fs');
+          const path = 'apps/servicebus-browser-app/src/app/constants.ts';
+          const version = process.env.TAG_VERSION;
+          const content = fs.readFileSync(path, 'utf8');
+          const updated = content.replace(/export const currentVersion = '.*';/, `export const currentVersion = '${version}';`);
+          fs.writeFileSync(path, updated);
+          EOF
       - run: pnpm exec nx run-many -t build --configuration=production
       - name: Build executable
         env:


### PR DESCRIPTION
## Summary
- patch the Electron `currentVersion` constant during the build-release workflow so it matches the release tag

## Testing
- `pnpm install --frozen-lockfile`
- `pnpm exec nx affected -t lint test build`

------
https://chatgpt.com/codex/tasks/task_e_6840b5e4e4708329bc136be32c7e3082