### PR TITLE
Improve update process

### DIFF
--- a/apps/servicebus-browser-app/src/app/events/update.events.ts
+++ b/apps/servicebus-browser-app/src/app/events/update.events.ts
@@ -1,4 +1,5 @@
-import { autoUpdater, dialog, MessageBoxOptions } from 'electron';
+import { autoUpdater, dialog, MessageBoxOptions, BrowserWindow } from 'electron';
+import { marked } from 'marked';
 import { platform, arch } from 'os';
 import { currentVersion, updateServerUrl } from '../constants';
 import App from '../app';
@@ -28,16 +29,37 @@ export default class UpdateEvents {
       autoUpdater.checkForUpdates();
     }
   }
+
+  private static async showReleaseNotes(title: string, notes: string) {
+    const win = new BrowserWindow({
+      width: 600,
+      height: 500,
+      modal: true,
+      parent: App.mainWindow,
+      show: false,
+      title,
+      webPreferences: { nodeIntegration: false }
+    });
+    const html = `<html><head><meta charset="UTF-8"><style>body{font-family:sans-serif;padding:20px;}</style></head><body>${marked.parse(notes)}</body></html>`;
+    win.loadURL('data:text/html;charset=utf-8,' + encodeURIComponent(html));
+    await new Promise((resolve) => {
+      win.once('ready-to-show', () => win.show());
+      win.on('closed', () => resolve(null));
+    });
+  }
 }
 
 autoUpdater.on(
   'update-downloaded',
-  (event, releaseNotes, releaseName, releaseDate) => {
+  (event, releaseNotes, releaseName) => {
+    if (App.mainWindow) {
+      App.mainWindow.setProgressBar(-1);
+    }
     const dialogOpts: MessageBoxOptions = {
       type: 'info' as const,
       buttons: ['Restart', 'Later'],
       title: 'Application Update',
-      message: process.platform === 'win32' ? releaseNotes : releaseName,
+      message: releaseName,
       detail:
         'A new version has been downloaded. Restart the application to apply the updates.',
     };
@@ -52,12 +74,51 @@ autoUpdater.on('checking-for-update', () => {
   console.log('Checking for updates...\n');
 });
 
-autoUpdater.on('update-available', () => {
+autoUpdater.on('update-available', async (_event, info) => {
   console.log('New update available!\n');
+
+  let notes = '';
+  if (Array.isArray(info.releaseNotes)) {
+    notes = info.releaseNotes.map((n) => n.note).join('\n');
+  } else if (info.releaseNotes) {
+    notes = info.releaseNotes;
+  }
+
+  await UpdateEvents.showReleaseNotes(
+    info.releaseName ?? info.version ?? 'Update available',
+    notes
+  );
+
+  const { response } = await dialog.showMessageBox({
+    type: 'info',
+    buttons: ['Download', 'Later'],
+    title: 'Update Available',
+    message: info.releaseName ?? info.version ?? 'Update available',
+    detail: notes,
+  });
+
+  if (response === 0) {
+    autoUpdater.downloadUpdate();
+  }
+});
+
+autoUpdater.on('download-progress', (progressObj) => {
+  console.log(
+    `Downloading update... ${Math.round(progressObj.percent)}%`
+  );
+  if (App.mainWindow) {
+    App.mainWindow.setProgressBar(progressObj.percent / 100);
+  }
 });
 
 autoUpdater.on('update-not-available', () => {
   console.log('Up to date!\n');
+  dialog.showMessageBox({
+    type: 'info',
+    buttons: ['OK'],
+    title: 'No Updates',
+    message: 'You are running the latest version.'
+  });
 });
 
 autoUpdater.on('before-quit-for-update', () => {

--- a/apps/servicebus-browser-app/src/app/menu.ts
+++ b/apps/servicebus-browser-app/src/app/menu.ts
@@ -6,6 +6,7 @@ import {
   nativeTheme
 } from 'electron'
 import App from './app';
+import UpdateEvents from './events/update.events';
 
 export function getMenu(isDev: boolean) {
   const isMac = process.platform === 'darwin';
@@ -18,6 +19,12 @@ export function getMenu(isDev: boolean) {
         {
           label: 'About ' + app.name,
           role: 'about'
+        },
+        {
+          label: 'Check for Updates...',
+          click: () => {
+            UpdateEvents.checkForUpdates();
+          }
         },
         { type: 'separator' },
         {
@@ -46,6 +53,12 @@ export function getMenu(isDev: boolean) {
         {
           label: 'About ' + app.name,
           role: 'about'
+        },
+        {
+          label: 'Check for Updates...',
+          click: () => {
+            UpdateEvents.checkForUpdates();
+          }
         },
         { role: 'quit' }
       ]

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "jest-environment-jsdom": "^29.7.0",
     "jest-environment-node": "^29.7.0",
     "jest-preset-angular": "~14.4.2",
+    "marked": "^11.0.0",
     "nx": "21.1.1",
     "nx-electron": "^20.0.2",
     "prettier": "^2.8.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -204,6 +204,9 @@ importers:
       jest-preset-angular:
         specifier: ~14.4.2
         version: 14.4.2(@angular/compiler-cli@19.2.12(@angular/compiler@19.2.12)(typescript@5.7.3))(@angular/core@19.2.12(rxjs@7.8.2)(zone.js@0.15.0))(@angular/platform-browser-dynamic@19.2.12(@angular/common@19.2.12(@angular/core@19.2.12(rxjs@7.8.2)(zone.js@0.15.0))(rxjs@7.8.2))(@angular/compiler@19.2.12)(@angular/core@19.2.12(rxjs@7.8.2)(zone.js@0.15.0))(@angular/platform-browser@19.2.12(@angular/animations@19.2.12(@angular/common@19.2.12(@angular/core@19.2.12(rxjs@7.8.2)(zone.js@0.15.0))(rxjs@7.8.2))(@angular/core@19.2.12(rxjs@7.8.2)(zone.js@0.15.0)))(@angular/common@19.2.12(@angular/core@19.2.12(rxjs@7.8.2)(zone.js@0.15.0))(rxjs@7.8.2))(@angular/core@19.2.12(rxjs@7.8.2)(zone.js@0.15.0))))(@babel/core@7.27.4)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.27.4))(jest@29.7.0(@types/node@18.16.9)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@swc/core@1.5.29(@swc/helpers@0.5.17))(@types/node@18.16.9)(typescript@5.7.3)))(typescript@5.7.3)
+      marked:
+        specifier: ^11.0.0
+        version: 11.2.0
       nx:
         specifier: 21.1.1
         version: 21.1.1(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(@swc/types@0.1.21)(typescript@5.7.3))(@swc/core@1.5.29(@swc/helpers@0.5.17))
@@ -5897,6 +5900,11 @@ packages:
 
   makeerror@1.0.12:
     resolution: {integrity: sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==}
+
+  marked@11.2.0:
+    resolution: {integrity: sha512-HR0m3bvu0jAPYiIvLUUQtdg1g6D247//lvcekpHO1WMvbwDlwSkZAX9Lw4F4YHE1T0HaaNve0tuAWuV1UJ6vtw==}
+    engines: {node: '>= 18'}
+    hasBin: true
 
   matcher@3.0.0:
     resolution: {integrity: sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng==}
@@ -15957,6 +15965,8 @@ snapshots:
   makeerror@1.0.12:
     dependencies:
       tmpl: 1.0.5
+
+  marked@11.2.0: {}
 
   matcher@3.0.0:
     dependencies:


### PR DESCRIPTION
## Summary
- add release notes preview and download progress for app updates
- prompt to start download and show progress
- add a menu item to check for updates
- include `marked` dependency

## Testing
- `npx nx run-many -t lint test` *(fails: "@service-bus-browser/connections-flow:lint" task failed)*

------
https://chatgpt.com/codex/tasks/task_e_6840b8bb57188329a9a6fa533ca115dc