### PR TITLE
Add error tooltips in topology tree

### DIFF
--- a/libs/topology/components/src/lib/generic-tree-node/generic-tree-node.component.html
+++ b/libs/topology/components/src/lib/generic-tree-node/generic-tree-node.component.html
@@ -1,17 +1,33 @@
 <div class="line-container">
-  <span class="name" [pTooltip]="label()"><fa-icon [icon]="icon()"></fa-icon> {{ label() }}</span>
+  <span class="name" [pTooltip]="label()"
+    ><fa-icon [icon]="icon()"></fa-icon> {{ label() }}</span
+  >
   @if (quickAmounts(); as amounts) {
-    <span [pTooltip]="'Active messages: ' + amounts.activeMessageCount + '\nDead letters: ' + amounts.deadLetterMessageCount + '\nTransfered dead letters: ' + amounts.transferDeadLetterMessageCount" tooltipPosition="top">({{amounts.activeMessageCount}},{{amounts.deadLetterMessageCount}},{{amounts.transferDeadLetterMessageCount}})</span>
-  }
-
-  @if (showRefresh()) {
-    <div class="refresh-button" [ngClass]="{ 'spin': isRefreshing() }">
-      <p-button
-        [severity]="hasLoadingError() ? 'danger' : 'primary'"
-        icon="pi pi-refresh"
-        [rounded]="true"
-        [text]="true"
-        (click)="refresh($event)"/>
-    </div>
+  <span
+    [pTooltip]="
+      'Active messages: ' +
+      amounts.activeMessageCount +
+      '\nDead letters: ' +
+      amounts.deadLetterMessageCount +
+      '\nTransfered dead letters: ' +
+      amounts.transferDeadLetterMessageCount
+    "
+    tooltipPosition="top"
+    >({{ amounts.activeMessageCount }},{{ amounts.deadLetterMessageCount }},{{
+      amounts.transferDeadLetterMessageCount
+    }})</span
+  >
+  } @if (showRefresh()) {
+  <div class="refresh-button" [ngClass]="{ spin: isRefreshing() }">
+    <p-button
+      [severity]="hasLoadingError() ? 'danger' : 'primary'"
+      icon="pi pi-refresh"
+      [rounded]="true"
+      [text]="true"
+      [pTooltip]="error()?.detail"
+      [tooltipDisabled]="!error()"
+      (click)="refresh($event)"
+    />
+  </div>
   }
 </div>

--- a/libs/topology/components/src/lib/generic-tree-node/generic-tree-node.component.ts
+++ b/libs/topology/components/src/lib/generic-tree-node/generic-tree-node.component.ts
@@ -1,17 +1,15 @@
 import { Component, input, output } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { Button } from 'primeng/button';
-import { FaIconComponent, IconDefinition } from '@fortawesome/angular-fontawesome';
+import {
+  FaIconComponent,
+  IconDefinition,
+} from '@fortawesome/angular-fontawesome';
 import { Tooltip } from 'primeng/tooltip';
 
 @Component({
   selector: 'sbb-tpl-generic-tree-node',
-  imports: [
-    CommonModule,
-    Button,
-    FaIconComponent,
-    Tooltip,
-  ],
+  imports: [CommonModule, Button, FaIconComponent, Tooltip],
   templateUrl: './generic-tree-node.component.html',
   styleUrl: './generic-tree-node.component.scss',
 })
@@ -27,6 +25,9 @@ export class GenericTreeNodeComponent<T> {
   showRefresh = input<boolean>(false);
   isRefreshing = input<boolean>(false);
   hasLoadingError = input<boolean>(false);
+  error = input<
+    import('@service-bus-browser/shared-contracts').Problem | undefined
+  >();
   refreshData = output();
 
   refresh($event: MouseEvent) {

--- a/libs/topology/components/src/lib/topic-tree-node/topic-tree-node.component.html
+++ b/libs/topology/components/src/lib/topic-tree-node/topic-tree-node.component.html
@@ -5,5 +5,6 @@
   [showRefresh]="showRefresh()"
   [isRefreshing]="topic().isLoading"
   [hasLoadingError]="topic().hasLoadingError"
+  [error]="topic().loadingError"
   (refreshData)="onRefresh()"
 />

--- a/libs/topology/components/src/lib/topology-tree/topology-tree.component.html
+++ b/libs/topology/components/src/lib/topology-tree/topology-tree.component.html
@@ -16,27 +16,39 @@
   <ng-template let-node pTemplate="queues">
     <div class="category-divider">
       <span class="name">{{ node.label }}</span>
-      <div class="refresh-button" [ngClass]="{ 'spin': node.data.isLoadingQueues }">
+      <div
+        class="refresh-button"
+        [ngClass]="{ spin: node.data.isLoadingQueues }"
+      >
         <p-button
           [severity]="node.data.hasQueuesLoadingError ? 'danger' : 'primary'"
           icon="pi pi-refresh"
           [rounded]="true"
           [text]="true"
-          (click)="refreshQueues($event, node.data)"/>
+          [pTooltip]="node.data.queueLoadingError?.detail"
+          [tooltipDisabled]="!node.data.queueLoadingError"
+          (click)="refreshQueues($event, node.data)"
+        />
       </div>
     </div>
   </ng-template>
   <ng-template let-node pTemplate="topics">
     <div class="category-divider">
       <span class="name">{{ node.label }}</span>
-      <div class="refresh-button" [ngClass]="{ 'spin': node.data.isLoadingTopics }">
+      <div
+        class="refresh-button"
+        [ngClass]="{ spin: node.data.isLoadingTopics }"
+      >
         <p-button
           icon="pi pi-refresh"
-          [severity]="node.data.hasQueuesLoadingError ? 'danger' : 'primary'"
+          [severity]="node.data.hasTopicsLoadingError ? 'danger' : 'primary'"
           [rounded]="true"
           [text]="true"
+          [pTooltip]="node.data.topicLoadingError?.detail"
+          [tooltipDisabled]="!node.data.topicLoadingError"
           [style]=""
-          (click)="refreshTopics($event, node.data)"/>
+          (click)="refreshTopics($event, node.data)"
+        />
       </div>
     </div>
   </ng-template>
@@ -55,7 +67,9 @@
     <sbb-tpl-subscription-tree-node
       [subscription]="node.data"
       [showRefresh]="displaySubscriptionRules()"
-      (refreshSubscription)="refreshSubscription($event.namespaceId, $event.topicId, $event.id)"
+      (refreshSubscription)="
+        refreshSubscription($event.namespaceId, $event.topicId, $event.id)
+      "
     />
   </ng-template>
   <ng-template let-node pTemplate="subscription-rule">

--- a/libs/topology/contracts/src/lib/namespace.ts
+++ b/libs/topology/contracts/src/lib/namespace.ts
@@ -1,11 +1,11 @@
 import { QueueWithMetaData } from './queue';
 import { TopicWithChildrenAndLoadingState, TopicWithMetaData } from './topic';
-import { UUID } from '@service-bus-browser/shared-contracts';
+import { UUID, Problem } from '@service-bus-browser/shared-contracts';
 
 export type Namespace = {
   id: UUID;
   name: string;
-}
+};
 
 export type NamespaceWithChildren<
   TQueue extends QueueWithMetaData = QueueWithMetaData,
@@ -13,12 +13,16 @@ export type NamespaceWithChildren<
 > = Namespace & {
   topics: TTopic[];
   queues: TQueue[];
-}
+};
 
-
-export type NamespaceWithChildrenAndLoadingState = NamespaceWithChildren<QueueWithMetaData, TopicWithChildrenAndLoadingState> & {
-  isLoadingQueues: boolean,
-  isLoadingTopics: boolean,
-  hasQueuesLoadingError: boolean,
-  hasTopicsLoadingError: boolean
+export type NamespaceWithChildrenAndLoadingState = NamespaceWithChildren<
+  QueueWithMetaData,
+  TopicWithChildrenAndLoadingState
+> & {
+  isLoadingQueues: boolean;
+  isLoadingTopics: boolean;
+  hasQueuesLoadingError: boolean;
+  queueLoadingError?: Problem | null;
+  hasTopicsLoadingError: boolean;
+  topicLoadingError?: Problem | null;
 };

--- a/libs/topology/contracts/src/lib/topic.ts
+++ b/libs/topology/contracts/src/lib/topic.ts
@@ -1,5 +1,8 @@
-import { SubscriptionWithMetaData, SubscriptionWithMetaDataAndLoadingState } from './subscription';
-import { UUID } from '@service-bus-browser/shared-contracts';
+import {
+  SubscriptionWithMetaData,
+  SubscriptionWithMetaDataAndLoadingState,
+} from './subscription';
+import { UUID, Problem } from '@service-bus-browser/shared-contracts';
 
 export type Topic = {
   namespaceId: UUID;
@@ -19,8 +22,8 @@ export type Topic = {
     supportOrdering: boolean;
     enablePartitioning: boolean;
     enableExpress: boolean;
-  },
-}
+  };
+};
 
 export type TopicWithMetaData = Topic & {
   metadata: {
@@ -57,14 +60,18 @@ export type TopicWithMetaData = Topic & {
      * The endpoint URL for the entity.
      */
     endpoint: string;
-  }
-}
-
-export type TopicWithChildren<TSubscription extends SubscriptionWithMetaData = SubscriptionWithMetaData> = TopicWithMetaData & {
-  subscriptions: TSubscription[];
-}
-
-export type TopicWithChildrenAndLoadingState = TopicWithChildren<SubscriptionWithMetaDataAndLoadingState> & {
-  isLoading: boolean,
-  hasLoadingError: boolean
+  };
 };
+
+export type TopicWithChildren<
+  TSubscription extends SubscriptionWithMetaData = SubscriptionWithMetaData
+> = TopicWithMetaData & {
+  subscriptions: TSubscription[];
+};
+
+export type TopicWithChildrenAndLoadingState =
+  TopicWithChildren<SubscriptionWithMetaDataAndLoadingState> & {
+    isLoading: boolean;
+    hasLoadingError: boolean;
+    loadingError?: Problem | null;
+  };

--- a/libs/topology/store/src/lib/topology.selectors.ts
+++ b/libs/topology/store/src/lib/topology.selectors.ts
@@ -1,73 +1,129 @@
 import { featureKey, TopologyState } from './topology.store';
 import { createFeatureSelector, createSelector } from '@ngrx/store';
 import {
-  NamespaceWithChildren, NamespaceWithChildrenAndLoadingState,
+  NamespaceWithChildren,
+  NamespaceWithChildrenAndLoadingState,
   QueueWithMetaData,
   SubscriptionWithMetaData,
-  TopicWithChildren, TopicWithChildrenAndLoadingState
+  TopicWithChildren,
+  TopicWithChildrenAndLoadingState,
 } from '@service-bus-browser/topology-contracts';
-import { UUID } from '@service-bus-browser/shared-contracts';
+import { UUID, Problem } from '@service-bus-browser/shared-contracts';
 import { ReceiveEndpoint } from '@service-bus-browser/service-bus-contracts';
 
 const featureSelector = createFeatureSelector<TopologyState>(featureKey);
 
-export const selectNamespaces = createSelector(
-  featureSelector,
-  (state) => state.namespaces.map<NamespaceWithChildrenAndLoadingState>((ns) => ({
+export const selectNamespaces = createSelector(featureSelector, (state) =>
+  state.namespaces.map<NamespaceWithChildrenAndLoadingState>((ns) => ({
     ...ns,
-    isLoadingQueues: state.queueLoadActions.some((a) => a.namespaceId === ns.id),
-    isLoadingTopics: state.topicLoadActions.some((a) => a.namespaceId === ns.id),
-    hasQueuesLoadingError: state.queueLoadErrors.some((a) => a.namespaceId === ns.id),
-    hasTopicsLoadingError: state.topicLoadErrors.some((a) => a.namespaceId === ns.id),
+    isLoadingQueues: state.queueLoadActions.some(
+      (a) => a.namespaceId === ns.id
+    ),
+    isLoadingTopics: state.topicLoadActions.some(
+      (a) => a.namespaceId === ns.id
+    ),
+    hasQueuesLoadingError: state.queueLoadErrors.some(
+      (a) => a.namespaceId === ns.id
+    ),
+    queueLoadingError:
+      state.queueLoadErrors.find((a) => a.namespaceId === ns.id)?.error ?? null,
+    hasTopicsLoadingError: state.topicLoadErrors.some(
+      (a) => a.namespaceId === ns.id
+    ),
+    topicLoadingError:
+      state.topicLoadErrors.find((a) => a.namespaceId === ns.id)?.error ?? null,
     queues: state.queuesPerNamespace[ns.id] ?? [],
-    topics: (state.topicsPerNamespace[ns.id] ?? []).map((topic): TopicWithChildrenAndLoadingState => ({
-      ...topic,
-      isLoading: state.subscriptionLoadActions.some((a) => a.namespaceId === ns.id && a.topicId === topic.id),
-      hasLoadingError: state.subscriptionLoadErrors.some((a) => a.namespaceId === ns.id && a.topicId === topic.id),
-      subscriptions: state.subscriptionsPerNamespaceAndTopic[ns.id]?.[topic.id]?.map(s => ({
-        ...s,
-        isLoading: state.rulesLoadActions.some((a) => a.namespaceId === ns.id && a.topicId === topic.id && a.subscriptionId === s.id),
-        hasLoadingError: state.rulesLoadErrors.some((a) => a.namespaceId === ns.id && a.topicId === topic.id && a.subscriptionId === s.id),
-      })) ?? [],
-    })),
+    topics: (state.topicsPerNamespace[ns.id] ?? []).map(
+      (topic): TopicWithChildrenAndLoadingState => ({
+        ...topic,
+        isLoading: state.subscriptionLoadActions.some(
+          (a) => a.namespaceId === ns.id && a.topicId === topic.id
+        ),
+        hasLoadingError: state.subscriptionLoadErrors.some(
+          (a) => a.namespaceId === ns.id && a.topicId === topic.id
+        ),
+        loadingError:
+          state.subscriptionLoadErrors.find(
+            (a) => a.namespaceId === ns.id && a.topicId === topic.id
+          )?.error ?? null,
+        subscriptions:
+          state.subscriptionsPerNamespaceAndTopic[ns.id]?.[topic.id]?.map(
+            (s) => ({
+              ...s,
+              isLoading: state.rulesLoadActions.some(
+                (a) =>
+                  a.namespaceId === ns.id &&
+                  a.topicId === topic.id &&
+                  a.subscriptionId === s.id
+              ),
+              hasLoadingError: state.rulesLoadErrors.some(
+                (a) =>
+                  a.namespaceId === ns.id &&
+                  a.topicId === topic.id &&
+                  a.subscriptionId === s.id
+              ),
+            })
+          ) ?? [],
+      })
+    ),
   }))
 );
 
-export const selectNamespaceById = (id: UUID) => createSelector(
-    selectNamespaces,
-    (namespaces) => namespaces.find((ns) => ns.id === id));
+export const selectNamespaceById = (id: UUID) =>
+  createSelector(selectNamespaces, (namespaces) =>
+    namespaces.find((ns) => ns.id === id)
+  );
 
+export const selectQueueById = (namespaceId: UUID, queueId: string) =>
+  createSelector(selectNamespaceById(namespaceId), (ns) =>
+    ns?.queues.find((q) => q.id === queueId)
+  );
 
-export const selectQueueById = (namespaceId: UUID, queueId: string) => createSelector(
-  selectNamespaceById(namespaceId),
-  (ns) =>  ns?.queues.find((q) => q.id === queueId)
-);
+export const selectTopicById = (namespaceId: UUID, topicId: string) =>
+  createSelector(selectNamespaceById(namespaceId), (ns) =>
+    ns?.topics.find((t) => t.id === topicId)
+  );
 
-export const selectTopicById = (namespaceId: UUID, topicId: string) => createSelector(
-  selectNamespaceById(namespaceId),
-  (ns) => ns?.topics.find((t) => t.id === topicId)
-);
+export const selectSubscriptionById = (
+  namespaceId: UUID,
+  topicId: string,
+  subscriptionId: string
+) =>
+  createSelector(selectTopicById(namespaceId, topicId), (topic) =>
+    topic?.subscriptions.find((s) => s.id === subscriptionId)
+  );
 
-export const selectSubscriptionById = (namespaceId: UUID, topicId: string, subscriptionId: string) => createSelector(
-  selectTopicById(namespaceId, topicId),
-  (topic) => topic?.subscriptions.find((s) => s.id === subscriptionId)
-);
+export const selectSubscriptionRuleById = (
+  namespaceId: UUID,
+  topicId: string,
+  subscriptionId: string,
+  ruleName: string
+) =>
+  createSelector(
+    selectSubscriptionById(namespaceId, topicId, subscriptionId),
+    (subscription) => subscription?.rules.find((r) => r.name === ruleName)
+  );
 
-export const selectSubscriptionRuleById = (namespaceId: UUID, topicId: string, subscriptionId: string, ruleName: string) => createSelector(
-  selectSubscriptionById(namespaceId, topicId, subscriptionId),
-  (subscription) => subscription?.rules.find((r) => r.name === ruleName)
-);
+export const selectByReceiveEndpoint = (receiveEndpoint: ReceiveEndpoint) =>
+  createSelector(
+    selectNamespaceById(receiveEndpoint.connectionId),
+    (namespace) => {
+      if ('queueName' in receiveEndpoint) {
+        return namespace?.queues.find(
+          (q) => q.name === receiveEndpoint.queueName
+        );
+      }
+      if (
+        'topicName' in receiveEndpoint &&
+        'subscriptionName' in receiveEndpoint
+      ) {
+        return namespace?.topics
+          .find((t) => t.name === receiveEndpoint.topicName)
+          ?.subscriptions.find(
+            (s) => s.name === receiveEndpoint.subscriptionName
+          );
+      }
 
-export const selectByReceiveEndpoint = (receiveEndpoint: ReceiveEndpoint) => createSelector(
-  selectNamespaceById(receiveEndpoint.connectionId),
-  (namespace) => {
-    if ('queueName' in receiveEndpoint) {
-      return namespace?.queues.find(q => q.name === receiveEndpoint.queueName);
+      return null;
     }
-    if ('topicName' in receiveEndpoint && 'subscriptionName' in receiveEndpoint) {
-      return namespace?.topics.find(t => t.name === receiveEndpoint.topicName)?.subscriptions.find(s => s.name === receiveEndpoint.subscriptionName);
-    }
-
-    return null;
-  }
-)
+  );

--- a/libs/topology/store/src/lib/topology.store.ts
+++ b/libs/topology/store/src/lib/topology.store.ts
@@ -8,7 +8,7 @@ import {
 
 import * as internalActions from './topology.internal-actions';
 import * as actions from './topology.actions';
-import { UUID } from '@service-bus-browser/shared-contracts';
+import { UUID, Problem } from '@service-bus-browser/shared-contracts';
 
 export const featureKey = 'topology';
 
@@ -20,14 +20,26 @@ export type TopologyState = {
     string,
     Record<string, SubscriptionWithMetaData[]>
   >;
-  queueLoadActions: Array<{ namespaceId: UUID }>
-  topicLoadActions: Array<{ namespaceId: UUID }>
-  subscriptionLoadActions: Array<{ namespaceId: UUID, topicId: string }>,
-  rulesLoadActions: Array<{ namespaceId: UUID, topicId: string, subscriptionId: string }>
-  queueLoadErrors: Array<{ namespaceId: UUID }>
-  topicLoadErrors: Array<{ namespaceId: UUID }>
-  subscriptionLoadErrors: Array<{ namespaceId: UUID, topicId: string }>,
-  rulesLoadErrors: Array<{ namespaceId: UUID, topicId: string, subscriptionId: string }>
+  queueLoadActions: Array<{ namespaceId: UUID }>;
+  topicLoadActions: Array<{ namespaceId: UUID }>;
+  subscriptionLoadActions: Array<{ namespaceId: UUID; topicId: string }>;
+  rulesLoadActions: Array<{
+    namespaceId: UUID;
+    topicId: string;
+    subscriptionId: string;
+  }>;
+  queueLoadErrors: Array<{ namespaceId: UUID; error: Problem }>;
+  topicLoadErrors: Array<{ namespaceId: UUID; error: Problem }>;
+  subscriptionLoadErrors: Array<{
+    namespaceId: UUID;
+    topicId: string;
+    error: Problem;
+  }>;
+  rulesLoadErrors: Array<{
+    namespaceId: UUID;
+    topicId: string;
+    subscriptionId: string;
+  }>;
 };
 
 export const initialState: TopologyState = {
@@ -42,147 +54,324 @@ export const initialState: TopologyState = {
   queueLoadErrors: [],
   topicLoadErrors: [],
   subscriptionLoadErrors: [],
-  rulesLoadErrors: []
+  rulesLoadErrors: [],
 };
 
 export const logsReducer = createReducer(
   initialState,
-  on(actions.loadQueues, actions.loadQueue, (state, { namespaceId }): TopologyState => ({
-    ...state,
-    queueLoadActions: [...state.queueLoadActions, { namespaceId }],
-  })),
-  on(internalActions.namespacesLoaded, (state, { namespaces }): TopologyState  => ({
-    ...state,
-    namespaces,
-  })),
-  on(internalActions.queuesLoaded, (state, { namespace, queues }): TopologyState  => ({
-    ...state,
-    queuesPerNamespace: {
-      ...state.queuesPerNamespace,
-      [namespace.id]: [...queues].sort((a, b) => a.name.localeCompare(b.name)),
-    },
-    queueLoadActions: state.queueLoadActions.filter(a => a.namespaceId !== namespace.id),
-    queueLoadErrors: state.queueLoadErrors.filter(a => a.namespaceId !== namespace.id)
-  })),
-  on(internalActions.queueLoaded, (state, { namespace, queue }): TopologyState  => ({
-    ...state,
-    queuesPerNamespace: {
-      ...state.queuesPerNamespace,
-      [namespace.id]: [...state.queuesPerNamespace[namespace.id].filter(q => q.id !== queue.id), queue]
-        .sort((a, b) => a.name.localeCompare(b.name)),
-    },
-    queueLoadActions: state.queueLoadActions.filter(a => a.namespaceId !== namespace.id)
-  })),
-  on(internalActions.failedToLoadQueues, internalActions.failedToLoadQueue, (state, { namespace }): TopologyState => ({
-    ...state,
-    queueLoadActions: namespace ? state.queueLoadActions.filter(a => a.namespaceId !== namespace.id) : state.queueLoadActions,
-    queueLoadErrors: namespace ? [...state.queueLoadErrors, { namespaceId: namespace.id }] : state.queueLoadErrors,
-  })),
-  on(actions.loadTopics, actions.loadTopic, (state, { namespaceId }): TopologyState => ({
-    ...state,
-    topicLoadActions: [...state.topicLoadActions, { namespaceId }],
-  })),
-  on(internalActions.topicsLoaded, (state, { namespace, topics }): TopologyState  => ({
-    ...state,
-    topicsPerNamespace: {
-      ...state.topicsPerNamespace,
-      [namespace.id]: [...topics].sort((a, b) => a.name.localeCompare(b.name)),
-    },
-    topicLoadActions: state.topicLoadActions.filter(a => a.namespaceId !== namespace.id),
-    topicLoadErrors: state.topicLoadErrors.filter(a => a.namespaceId !== namespace.id)
-  })),
-  on(internalActions.topicLoaded, (state, { namespace, topic }): TopologyState  => ({
-    ...state,
-    topicsPerNamespace: {
-      ...state.topicsPerNamespace,
-      [namespace.id]: [...state.topicsPerNamespace[namespace.id], topic].sort((a, b) => a.name.localeCompare(b.name)),
-    },
-    topicLoadActions: state.topicLoadActions.filter(a => a.namespaceId !== namespace.id)
-  })),
-  on(internalActions.failedToLoadTopics, internalActions.failedToLoadTopic, (state, { namespace }): TopologyState => ({
-    ...state,
-    topicLoadActions: namespace ? state.topicLoadActions.filter(a => a.namespaceId !== namespace.id) : state.topicLoadActions,
-    topicLoadErrors: namespace ? [...state.topicLoadErrors, { namespaceId: namespace.id }] : state.topicLoadErrors,
-  })),
-  on(actions.loadSubscriptions, (state, { namespaceId, topicId }): TopologyState => ({
-    ...state,
-    topicLoadActions: [...state.topicLoadActions, { namespaceId }],
-    subscriptionLoadActions: [...state.subscriptionLoadActions, { namespaceId, topicId }],
-  })),
-  on(actions.loadSubscription, (state, { namespaceId, topicId, subscriptionId }): TopologyState => ({
-    ...state,
-    topicLoadActions: [...state.topicLoadActions, { namespaceId }],
-    subscriptionLoadActions: [...state.subscriptionLoadActions, { namespaceId, topicId }],
-    rulesLoadActions: [...state.rulesLoadActions, { namespaceId, topicId, subscriptionId }]
-  })),
+  on(
+    actions.loadQueues,
+    actions.loadQueue,
+    (state, { namespaceId }): TopologyState => ({
+      ...state,
+      queueLoadActions: [...state.queueLoadActions, { namespaceId }],
+    })
+  ),
+  on(
+    internalActions.namespacesLoaded,
+    (state, { namespaces }): TopologyState => ({
+      ...state,
+      namespaces,
+    })
+  ),
+  on(
+    internalActions.queuesLoaded,
+    (state, { namespace, queues }): TopologyState => ({
+      ...state,
+      queuesPerNamespace: {
+        ...state.queuesPerNamespace,
+        [namespace.id]: [...queues].sort((a, b) =>
+          a.name.localeCompare(b.name)
+        ),
+      },
+      queueLoadActions: state.queueLoadActions.filter(
+        (a) => a.namespaceId !== namespace.id
+      ),
+      queueLoadErrors: state.queueLoadErrors.filter(
+        (a) => a.namespaceId !== namespace.id
+      ),
+    })
+  ),
+  on(
+    internalActions.queueLoaded,
+    (state, { namespace, queue }): TopologyState => ({
+      ...state,
+      queuesPerNamespace: {
+        ...state.queuesPerNamespace,
+        [namespace.id]: [
+          ...state.queuesPerNamespace[namespace.id].filter(
+            (q) => q.id !== queue.id
+          ),
+          queue,
+        ].sort((a, b) => a.name.localeCompare(b.name)),
+      },
+      queueLoadActions: state.queueLoadActions.filter(
+        (a) => a.namespaceId !== namespace.id
+      ),
+    })
+  ),
+  on(
+    internalActions.failedToLoadQueues,
+    internalActions.failedToLoadQueue,
+    (state, { namespace, error }): TopologyState => ({
+      ...state,
+      queueLoadActions: namespace
+        ? state.queueLoadActions.filter((a) => a.namespaceId !== namespace.id)
+        : state.queueLoadActions,
+      queueLoadErrors: namespace
+        ? [
+            ...state.queueLoadErrors.filter(
+              (e) => e.namespaceId !== namespace.id
+            ),
+            { namespaceId: namespace.id, error },
+          ]
+        : state.queueLoadErrors,
+    })
+  ),
+  on(
+    actions.loadTopics,
+    actions.loadTopic,
+    (state, { namespaceId }): TopologyState => ({
+      ...state,
+      topicLoadActions: [...state.topicLoadActions, { namespaceId }],
+    })
+  ),
+  on(
+    internalActions.topicsLoaded,
+    (state, { namespace, topics }): TopologyState => ({
+      ...state,
+      topicsPerNamespace: {
+        ...state.topicsPerNamespace,
+        [namespace.id]: [...topics].sort((a, b) =>
+          a.name.localeCompare(b.name)
+        ),
+      },
+      topicLoadActions: state.topicLoadActions.filter(
+        (a) => a.namespaceId !== namespace.id
+      ),
+      topicLoadErrors: state.topicLoadErrors.filter(
+        (a) => a.namespaceId !== namespace.id
+      ),
+    })
+  ),
+  on(
+    internalActions.topicLoaded,
+    (state, { namespace, topic }): TopologyState => ({
+      ...state,
+      topicsPerNamespace: {
+        ...state.topicsPerNamespace,
+        [namespace.id]: [...state.topicsPerNamespace[namespace.id], topic].sort(
+          (a, b) => a.name.localeCompare(b.name)
+        ),
+      },
+      topicLoadActions: state.topicLoadActions.filter(
+        (a) => a.namespaceId !== namespace.id
+      ),
+    })
+  ),
+  on(
+    internalActions.failedToLoadTopics,
+    internalActions.failedToLoadTopic,
+    (state, { namespace, error }): TopologyState => ({
+      ...state,
+      topicLoadActions: namespace
+        ? state.topicLoadActions.filter((a) => a.namespaceId !== namespace.id)
+        : state.topicLoadActions,
+      topicLoadErrors: namespace
+        ? [
+            ...state.topicLoadErrors.filter(
+              (e) => e.namespaceId !== namespace.id
+            ),
+            { namespaceId: namespace.id, error },
+          ]
+        : state.topicLoadErrors,
+    })
+  ),
+  on(
+    actions.loadSubscriptions,
+    (state, { namespaceId, topicId }): TopologyState => ({
+      ...state,
+      topicLoadActions: [...state.topicLoadActions, { namespaceId }],
+      subscriptionLoadActions: [
+        ...state.subscriptionLoadActions,
+        { namespaceId, topicId },
+      ],
+    })
+  ),
+  on(
+    actions.loadSubscription,
+    (state, { namespaceId, topicId, subscriptionId }): TopologyState => ({
+      ...state,
+      topicLoadActions: [...state.topicLoadActions, { namespaceId }],
+      subscriptionLoadActions: [
+        ...state.subscriptionLoadActions,
+        { namespaceId, topicId },
+      ],
+      rulesLoadActions: [
+        ...state.rulesLoadActions,
+        { namespaceId, topicId, subscriptionId },
+      ],
+    })
+  ),
   on(
     internalActions.subscriptionsLoaded,
-    (state, { namespace, topic, subscriptions }): TopologyState  => ({
+    (state, { namespace, topic, subscriptions }): TopologyState => ({
       ...state,
       subscriptionsPerNamespaceAndTopic: {
         ...state.subscriptionsPerNamespaceAndTopic,
         [namespace.id]: {
           ...state.subscriptionsPerNamespaceAndTopic[namespace.id],
-          [topic.id]: [...subscriptions].sort((a, b) => a.name.localeCompare(b.name)),
+          [topic.id]: [...subscriptions].sort((a, b) =>
+            a.name.localeCompare(b.name)
+          ),
         },
       },
-      topicLoadActions: state.topicLoadActions.filter(a => a.namespaceId !== namespace.id),
-      subscriptionLoadActions: state.subscriptionLoadActions.filter(a => a.namespaceId !== namespace.id && a.topicId !== topic.id),
-      subscriptionLoadErrors: state.subscriptionLoadErrors.filter(a => a.namespaceId !== namespace.id && a.topicId !== topic.id)
+      topicLoadActions: state.topicLoadActions.filter(
+        (a) => a.namespaceId !== namespace.id
+      ),
+      subscriptionLoadActions: state.subscriptionLoadActions.filter(
+        (a) => a.namespaceId !== namespace.id && a.topicId !== topic.id
+      ),
+      subscriptionLoadErrors: state.subscriptionLoadErrors.filter(
+        (a) => a.namespaceId !== namespace.id && a.topicId !== topic.id
+      ),
     })
   ),
-  on(internalActions.failedToLoadSubscriptions, (state, { namespace, topic }): TopologyState => ({
-    ...state,
-    topicLoadActions: namespace ? state.topicLoadActions.filter(a => a.namespaceId !== namespace.id) : state.topicLoadActions,
-    subscriptionLoadActions: namespace && topic ? state.subscriptionLoadActions.filter(a => a.namespaceId !== namespace.id && a.topicId !== topic.id) : state.subscriptionLoadActions,
-    subscriptionLoadErrors: namespace && topic ? [...state.subscriptionLoadErrors, { namespaceId: namespace.id, topicId: topic.id }] : state.subscriptionLoadErrors,
-  })),
-  on(internalActions.subscriptionLoaded, (state, { namespace, topic, subscription }): TopologyState  => ({
-    ...state,
-    subscriptionsPerNamespaceAndTopic: {
-      ...state.subscriptionsPerNamespaceAndTopic,
-      [namespace.id]: {
-        ...state.subscriptionsPerNamespaceAndTopic[namespace.id],
-        [topic.id]: [...state.subscriptionsPerNamespaceAndTopic[namespace.id][topic.id].filter(s => s.id !== subscription.id), subscription].sort((a, b) => a.name.localeCompare(b.name)),
+  on(
+    internalActions.failedToLoadSubscriptions,
+    (state, { namespace, topic, error }): TopologyState => ({
+      ...state,
+      topicLoadActions: namespace
+        ? state.topicLoadActions.filter((a) => a.namespaceId !== namespace.id)
+        : state.topicLoadActions,
+      subscriptionLoadActions:
+        namespace && topic
+          ? state.subscriptionLoadActions.filter(
+              (a) => a.namespaceId !== namespace.id && a.topicId !== topic.id
+            )
+          : state.subscriptionLoadActions,
+      subscriptionLoadErrors:
+        namespace && topic
+          ? [
+              ...state.subscriptionLoadErrors.filter(
+                (e) =>
+                  !(e.namespaceId === namespace.id && e.topicId === topic.id)
+              ),
+              { namespaceId: namespace.id, topicId: topic.id, error },
+            ]
+          : state.subscriptionLoadErrors,
+    })
+  ),
+  on(
+    internalActions.subscriptionLoaded,
+    (state, { namespace, topic, subscription }): TopologyState => ({
+      ...state,
+      subscriptionsPerNamespaceAndTopic: {
+        ...state.subscriptionsPerNamespaceAndTopic,
+        [namespace.id]: {
+          ...state.subscriptionsPerNamespaceAndTopic[namespace.id],
+          [topic.id]: [
+            ...state.subscriptionsPerNamespaceAndTopic[namespace.id][
+              topic.id
+            ].filter((s) => s.id !== subscription.id),
+            subscription,
+          ].sort((a, b) => a.name.localeCompare(b.name)),
+        },
       },
-    },
-    topicLoadActions: state.topicLoadActions.filter(a => a.namespaceId !== namespace.id),
-    subscriptionLoadActions: state.subscriptionLoadActions.filter(a => a.namespaceId !== namespace.id && a.topicId !== topic.id),
-    rulesLoadActions: state.rulesLoadActions.filter(a => a.namespaceId !== namespace.id && a.topicId !== topic.id && a.subscriptionId !== subscription.id),
-    rulesLoadErrors: state.rulesLoadErrors.filter(a => a.namespaceId !== namespace.id && a.topicId !== topic.id && a.subscriptionId !== subscription.id)
-  })),
-  on(internalActions.failedToLoadSubscription, (state, { namespace, topic, subscriptionId }): TopologyState => ({
-    ...state,
-    topicLoadActions: namespace ? state.topicLoadActions.filter(a => a.namespaceId !== namespace.id) : state.topicLoadActions,
-    subscriptionLoadActions: namespace && topic ? state.subscriptionLoadActions.filter(a => a.namespaceId !== namespace.id && a.topicId !== topic.id) : state.subscriptionLoadActions,
-    rulesLoadActions: namespace && topic && subscriptionId ? state.rulesLoadActions.filter(a => a.namespaceId !== namespace.id && a.topicId !== topic.id && a.subscriptionId !== subscriptionId) : state.rulesLoadActions,
-    rulesLoadErrors: namespace && topic && subscriptionId ? [...state.rulesLoadErrors, { namespaceId: namespace.id, topicId: topic.id, subscriptionId: subscriptionId }] : state.rulesLoadErrors,
-  })),
-  on(internalActions.queueRemoved, (state, {namespace, queueId}): TopologyState  => ({
-    ...state,
-    queuesPerNamespace: {
-      ...state.queuesPerNamespace,
-      [namespace.id]: state.queuesPerNamespace[namespace.id].filter(queue => queue.id !== queueId)
-    }
-  })),
-  on(internalActions.topicRemoved, (state, {namespace, topicId}): TopologyState  => ({
+      topicLoadActions: state.topicLoadActions.filter(
+        (a) => a.namespaceId !== namespace.id
+      ),
+      subscriptionLoadActions: state.subscriptionLoadActions.filter(
+        (a) => a.namespaceId !== namespace.id && a.topicId !== topic.id
+      ),
+      rulesLoadActions: state.rulesLoadActions.filter(
+        (a) =>
+          a.namespaceId !== namespace.id &&
+          a.topicId !== topic.id &&
+          a.subscriptionId !== subscription.id
+      ),
+      rulesLoadErrors: state.rulesLoadErrors.filter(
+        (a) =>
+          a.namespaceId !== namespace.id &&
+          a.topicId !== topic.id &&
+          a.subscriptionId !== subscription.id
+      ),
+    })
+  ),
+  on(
+    internalActions.failedToLoadSubscription,
+    (state, { namespace, topic, subscriptionId }): TopologyState => ({
+      ...state,
+      topicLoadActions: namespace
+        ? state.topicLoadActions.filter((a) => a.namespaceId !== namespace.id)
+        : state.topicLoadActions,
+      subscriptionLoadActions:
+        namespace && topic
+          ? state.subscriptionLoadActions.filter(
+              (a) => a.namespaceId !== namespace.id && a.topicId !== topic.id
+            )
+          : state.subscriptionLoadActions,
+      rulesLoadActions:
+        namespace && topic && subscriptionId
+          ? state.rulesLoadActions.filter(
+              (a) =>
+                a.namespaceId !== namespace.id &&
+                a.topicId !== topic.id &&
+                a.subscriptionId !== subscriptionId
+            )
+          : state.rulesLoadActions,
+      rulesLoadErrors:
+        namespace && topic && subscriptionId
+          ? [
+              ...state.rulesLoadErrors,
+              {
+                namespaceId: namespace.id,
+                topicId: topic.id,
+                subscriptionId: subscriptionId,
+              },
+            ]
+          : state.rulesLoadErrors,
+    })
+  ),
+  on(
+    internalActions.queueRemoved,
+    (state, { namespace, queueId }): TopologyState => ({
+      ...state,
+      queuesPerNamespace: {
+        ...state.queuesPerNamespace,
+        [namespace.id]: state.queuesPerNamespace[namespace.id].filter(
+          (queue) => queue.id !== queueId
+        ),
+      },
+    })
+  ),
+  on(
+    internalActions.topicRemoved,
+    (state, { namespace, topicId }): TopologyState => ({
       ...state,
       topicsPerNamespace: {
         ...state.topicsPerNamespace,
-        [namespace.id]: state.topicsPerNamespace[namespace.id].filter(topic => topic.id !== topicId)
-      }
-    }
-  )),
-  on(internalActions.subscriptionRemoved, (state, {namespace, topic, subscriptionId}): TopologyState  => ({
-    ...state,
-    subscriptionsPerNamespaceAndTopic: {
-      ...state.subscriptionsPerNamespaceAndTopic,
-      [namespace.id]: {
-        ...state.subscriptionsPerNamespaceAndTopic[namespace.id],
-        [topic.id]: state.subscriptionsPerNamespaceAndTopic[namespace.id][topic.id].filter(subscription => subscription.id !== subscriptionId)
-      }
-    }
-  }))
+        [namespace.id]: state.topicsPerNamespace[namespace.id].filter(
+          (topic) => topic.id !== topicId
+        ),
+      },
+    })
+  ),
+  on(
+    internalActions.subscriptionRemoved,
+    (state, { namespace, topic, subscriptionId }): TopologyState => ({
+      ...state,
+      subscriptionsPerNamespaceAndTopic: {
+        ...state.subscriptionsPerNamespaceAndTopic,
+        [namespace.id]: {
+          ...state.subscriptionsPerNamespaceAndTopic[namespace.id],
+          [topic.id]: state.subscriptionsPerNamespaceAndTopic[namespace.id][
+            topic.id
+          ].filter((subscription) => subscription.id !== subscriptionId),
+        },
+      },
+    })
+  )
 );
 
 export const topologyFeature = createFeature({


### PR DESCRIPTION
## Summary
- store loading errors and make them accessible in selectors
- surface error message on topology tree buttons
- show tooltips on refresh buttons when queues, topics or subscriptions fail to load

## Testing
- `pnpm exec nx format:write`
- `pnpm exec nx test @service-bus-browser/topology-components`
- `pnpm exec nx test @service-bus-browser/topology-store`

------
https://chatgpt.com/codex/tasks/task_e_6840ba201ae0832988b16691e54c8cfa