### PR TITLE
Fix fullscreen menubar on mac

### DIFF
--- a/apps/servicebus-browser-app/src/app/api/main.preload.ts
+++ b/apps/servicebus-browser-app/src/app/api/main.preload.ts
@@ -3,9 +3,17 @@ import { contextBridge, ipcRenderer } from 'electron';
 contextBridge.exposeInMainWorld('electron', {
   getAppVersion: () => ipcRenderer.invoke('get-app-version'),
   platform: process.platform,
+  onFullScreenChanged: (callback: (fullscreen: boolean) => void) =>
+    ipcRenderer.on('fullscreen-changed', (_, full) => callback(full)),
 });
 
 contextBridge.exposeInMainWorld('serviceBusApi', {
-  managementDoRequest: (requestType: string, request) => ipcRenderer.invoke('service-bus:management-do-request', requestType, request),
-  messagesDoRequest: (requestType: string, request) => ipcRenderer.invoke('service-bus:messages-do-request', requestType, request),
-})
+  managementDoRequest: (requestType: string, request) =>
+    ipcRenderer.invoke(
+      'service-bus:management-do-request',
+      requestType,
+      request
+    ),
+  messagesDoRequest: (requestType: string, request) =>
+    ipcRenderer.invoke('service-bus:messages-do-request', requestType, request),
+});

--- a/apps/servicebus-browser-app/src/app/app.ts
+++ b/apps/servicebus-browser-app/src/app/app.ts
@@ -78,13 +78,21 @@ export default class App {
         preload: join(__dirname, 'main.preload.js'),
       },
     });
-    App.setTheme("system");
+    App.setTheme('system');
     App.mainWindow.setMenu(null);
     App.mainWindow.center();
 
+    App.mainWindow.on('enter-full-screen', () => {
+      App.mainWindow.webContents.send('fullscreen-changed', true);
+    });
+
+    App.mainWindow.on('leave-full-screen', () => {
+      App.mainWindow.webContents.send('fullscreen-changed', false);
+    });
+
     // if main window is ready to show, close the splash window and show the main window
     App.mainWindow.once('ready-to-show', () => {
-      Menu.setApplicationMenu(getMenu((App.isDevelopmentMode())));
+      Menu.setApplicationMenu(getMenu(App.isDevelopmentMode()));
       App.mainWindow.show();
     });
 

--- a/apps/servicebus-browser-frontend/src/app/app.component.scss
+++ b/apps/servicebus-browser-frontend/src/app/app.component.scss
@@ -6,6 +6,7 @@
   .main-menu {
     .p-menubar {
       padding: 3px 0;
+      min-height: 32px;
       border-radius: 0;
       z-index: 2;
       position: relative;
@@ -18,11 +19,14 @@
 
     &.mac {
       .p-menubar {
-        @media all and (display-mode: fullscreen) {
-          padding-left: 0px;
-        }
         padding-left: 70px;
       }
+    }
+  }
+
+  body.fullscreen & .main-menu.mac {
+    .p-menubar {
+      padding-left: 0;
     }
   }
 

--- a/apps/servicebus-browser-frontend/src/app/app.component.ts
+++ b/apps/servicebus-browser-frontend/src/app/app.component.ts
@@ -21,6 +21,13 @@ import { Button } from 'primeng/button';
 import { ColorThemeService } from '@service-bus-browser/services';
 import { NgClass } from '@angular/common';
 
+interface ElectronWindow {
+  electron?: {
+    platform?: string;
+    onFullScreenChanged?: (callback: (fullscreen: boolean) => void) => void;
+  };
+}
+
 @Component({
   imports: [
     RouterModule,
@@ -43,10 +50,8 @@ import { NgClass } from '@angular/common';
 })
 export class AppComponent {
   title = 'servicebus-browser-frontend';
-  isMac =
-    'userAgentData' in navigator &&
-    ((navigator.userAgentData as any)?.platform.toLowerCase().includes('mac') ??
-      false);
+  private electron = (window as unknown as ElectronWindow).electron;
+  isMac = this.electron?.platform === 'darwin';
 
   menuItems: MenuItem[] = [
     {
@@ -124,6 +129,9 @@ export class AppComponent {
   constructor() {
     this.setDarkMode(this.darkMode());
     effect(() => this.setDarkMode(this.darkMode()));
+    this.electron?.onFullScreenChanged?.((full) => {
+      document.body.classList.toggle('fullscreen', full);
+    });
   }
 
   importMessages(): void {


### PR DESCRIPTION
## Summary
- expose fullscreen change events to the renderer
- notify renderer when the window enters/leaves fullscreen
- toggle fullscreen class in the Angular app
- remove padding in fullscreen and set consistent menubar height

## Testing
- `pnpm exec nx run-many -t test --all`

------
https://chatgpt.com/codex/tasks/task_e_68420e3c1a20832997fabb676d53c282