### PR TITLE
Add messages counter with filters

### DIFF
--- a/libs/messages/flow/src/lib/messages-page/messages-page.component.html
+++ b/libs/messages/flow/src/lib/messages-page/messages-page.component.html
@@ -8,7 +8,7 @@
   />
   <p-card class="messages">
     <div class="messages-header">
-      <div class="p-card-title">Messages</div>
+      <div class="p-card-title">Messages ({{ filteredMessageCount() }}/{{ totalMessageCount() }})</div>
       <div class="header-buttons">
         <p-button (click)="openFilterDialog()" [icon]="hasActiveFilters() ? 'pi pi-filter-fill' : 'pi pi-filter'" text="true"/>
         <p-button (click)="menu.show($event)" icon="pi pi-ellipsis-v" text="true"/>

--- a/libs/messages/flow/src/lib/messages-page/messages-page.component.ts
+++ b/libs/messages/flow/src/lib/messages-page/messages-page.component.ts
@@ -78,6 +78,8 @@ export class MessagesPageComponent {
     applicationProperties: [],
     body: []
   });
+  totalMessageCount = computed(() => this.currentPage()?.messages.length ?? 0);
+  filteredMessageCount = computed(() => this.filteredMessages().length);
   hasActiveFilters = computed(() => {
     return this.messageFilterService.hasActiveFilters(this.messageFilter());
   });


### PR DESCRIPTION
## Summary
- show count of messages considering active filters and total count

## Testing
- `pnpm exec nx lint @service-bus-browser/messages-flow`
- `pnpm exec nx test @service-bus-browser/messages-flow`

------
https://chatgpt.com/codex/tasks/task_e_68494053d9c483299c31eb85d4445de9