### PR TITLE
Add manual update search option

### DIFF
--- a/apps/servicebus-browser-app/src/app/api/main.preload.ts
+++ b/apps/servicebus-browser-app/src/app/api/main.preload.ts
@@ -5,6 +5,7 @@ contextBridge.exposeInMainWorld('electron', {
   platform: process.platform,
   onFullScreenChanged: (callback: (fullscreen: boolean) => void) =>
     ipcRenderer.on('fullscreen-changed', (_, full) => callback(full)),
+  checkForUpdates: () => ipcRenderer.invoke('check-for-updates'),
 });
 
 contextBridge.exposeInMainWorld('serviceBusApi', {

--- a/apps/servicebus-browser-app/src/app/events/electron.events.ts
+++ b/apps/servicebus-browser-app/src/app/events/electron.events.ts
@@ -4,6 +4,7 @@
  */
 
 import { app, ipcMain } from 'electron';
+import UpdateEvents from './update.events';
 import { environment } from '../../environments/environment';
 
 export default class ElectronEvents {
@@ -17,6 +18,11 @@ ipcMain.handle('get-app-version', (event) => {
   console.log(`Fetching application version... [v${environment.version}]`);
 
   return environment.version;
+});
+
+// Manual update check
+ipcMain.handle('check-for-updates', () => {
+  UpdateEvents.checkForUpdates(true);
 });
 
 // Handle App termination

--- a/apps/servicebus-browser-frontend/src/app/app.component.ts
+++ b/apps/servicebus-browser-frontend/src/app/app.component.ts
@@ -25,6 +25,7 @@ interface ElectronWindow {
   electron?: {
     platform?: string;
     onFullScreenChanged?: (callback: (fullscreen: boolean) => void) => void;
+    checkForUpdates?: () => Promise<void>;
   };
 }
 
@@ -98,18 +99,23 @@ export class AppComponent {
               icon: 'pi pi-sun',
               command: () => this.themeService.setPreference('light'),
             },
-        {
-          label: 'Dark theme',
-          icon: 'pi pi-moon',
-          command: () => this.themeService.setPreference('dark'),
+            {
+              label: 'Dark theme',
+              icon: 'pi pi-moon',
+              command: () => this.themeService.setPreference('dark'),
+            },
+          ],
         },
-      ],
+        {
+          label: 'Search for Updates',
+          icon: 'pi pi-refresh',
+          command: () => this.electron?.checkForUpdates?.(),
         },
         {
           label: 'About',
           icon: 'pi pi-info-circle',
-          routerLink: '/about'
-        }
+          routerLink: '/about',
+        },
       ],
     },
   ];


### PR DESCRIPTION
## Summary
- allow frontend to trigger electron autoUpdater
- handle manual update checks in the backend
- show "Search for Updates" in Settings menu

## Testing
- `npx nx run-many --target=lint --all`
- `npx nx run-many --target=test --all`


------
https://chatgpt.com/codex/tasks/task_e_68493ea4fa908329a3218af239b6d261