### PR TITLE
Add update notification

### DIFF
--- a/apps/servicebus-browser-app/src/app/api/main.preload.ts
+++ b/apps/servicebus-browser-app/src/app/api/main.preload.ts
@@ -5,6 +5,8 @@ contextBridge.exposeInMainWorld('electron', {
   platform: process.platform,
   onFullScreenChanged: (callback: (fullscreen: boolean) => void) =>
     ipcRenderer.on('fullscreen-changed', (_, full) => callback(full)),
+  onUpdateAvailable: (callback: () => void) =>
+    ipcRenderer.on('update-available', () => callback()),
   checkForUpdates: () => ipcRenderer.invoke('check-for-updates'),
 });
 

--- a/apps/servicebus-browser-app/src/app/events/update.events.ts
+++ b/apps/servicebus-browser-app/src/app/events/update.events.ts
@@ -23,9 +23,9 @@ export default class UpdateEvents {
       url: `${updateServerUrl}/mligtenberg/ServicebusBrowser/${platform_arch}/${currentVersion}`,
     };
 
-
     console.log('Initializing auto update service...');
     autoUpdater.setFeedURL(feed);
+    autoUpdater.autoDownload = false;
 
     if (!App.isDevelopmentMode()) {
       UpdateEvents.checkForUpdates();
@@ -34,8 +34,8 @@ export default class UpdateEvents {
 
   // check for updates - most be invoked after initAutoUpdateService() and only in production
   static checkForUpdates(manual = false) {
-      UpdateEvents.setManualCheck(manual);
-      autoUpdater.checkForUpdates();
+    UpdateEvents.setManualCheck(manual);
+    autoUpdater.checkForUpdates();
   }
 }
 
@@ -64,6 +64,19 @@ autoUpdater.on('checking-for-update', () => {
 
 autoUpdater.on('update-available', () => {
   console.log('New update available!\n');
+  App.mainWindow?.webContents.send('update-available');
+  const dialogOpts: MessageBoxOptions = {
+    type: 'info',
+    buttons: ['Download', 'Later'],
+    title: 'Application Update',
+    message: 'A new update is available.',
+    detail: 'Do you want to download and install this update?',
+  };
+  dialog.showMessageBox(dialogOpts).then((returnValue) => {
+    if (returnValue.response === 0) {
+      autoUpdater.downloadUpdate();
+    }
+  });
   UpdateEvents.setManualCheck(false);
 });
 

--- a/apps/servicebus-browser-frontend/src/app/app.component.ts
+++ b/apps/servicebus-browser-frontend/src/app/app.component.ts
@@ -11,6 +11,7 @@ import { Store } from '@ngrx/store';
 import { LogsSelectors } from '@service-bus-browser/logs-store';
 import { SidebarComponent } from './sidebar/sidebar.component';
 import { Toast } from 'primeng/toast';
+import { MessageService } from 'primeng/api';
 import {
   MessagesActions,
   MessagesSelectors,
@@ -25,6 +26,7 @@ interface ElectronWindow {
   electron?: {
     platform?: string;
     onFullScreenChanged?: (callback: (fullscreen: boolean) => void) => void;
+    onUpdateAvailable?: (callback: () => void) => void;
     checkForUpdates?: () => Promise<void>;
   };
 }
@@ -128,6 +130,7 @@ export class AppComponent {
   logs = this.store.selectSignal(LogsSelectors.selectLogs);
   messagePages = this.store.selectSignal(MessagesSelectors.selectPages);
   darkMode = this.themeService.darkMode;
+  private messageService = inject(MessageService);
 
   toggleLogs() {
     this.logsOpened.update((value) => !value);
@@ -143,6 +146,13 @@ export class AppComponent {
     effect(() => this.setDarkMode(this.darkMode()));
     this.electron?.onFullScreenChanged?.((full) => {
       document.body.classList.toggle('fullscreen', full);
+    });
+    this.electron?.onUpdateAvailable?.(() => {
+      this.messageService.add({
+        severity: 'info',
+        summary: 'Update available',
+        detail: 'A new version is available.',
+      });
     });
   }
 


### PR DESCRIPTION
## Summary
- expose new `onUpdateAvailable` IPC listener in preload
- notify renderer from main process when update is available
- prompt user before downloading
- show toast message when an update is available

## Testing
- `npx nx format:check`
- `npx nx lint servicebus-browser-app`
- `npx nx lint servicebus-browser-frontend`
- `npx nx test servicebus-browser-app`
- `npx nx test servicebus-browser-frontend`

------
https://chatgpt.com/codex/tasks/task_e_684c7df80524832989a9b3f502e8ba07