### PR TITLE
Add unit tests for Angular code

### DIFF
--- a/libs/connections/store/src/lib/connections.store.spec.ts
+++ b/libs/connections/store/src/lib/connections.store.spec.ts
@@ -1,0 +1,31 @@
+import { connectionsFeature, initialState } from './connections.store';
+import * as Actions from './connections.actions';
+import * as InternalActions from './connections.internal-actions';
+import { Connection } from '@service-bus-browser/service-bus-contracts';
+
+describe('connections reducer', () => {
+  const connection: Connection = {
+    id: '00000000-0000-0000-0000-000000000001',
+    type: 'connectionString',
+    name: 'conn',
+    connectionString: 'Endpoint=sb://test/'
+  };
+
+  it('marks connection under test', () => {
+    const state = connectionsFeature.reducer(initialState, Actions.checkConnection({ connection }));
+    expect(state.connectionUnderTest).toEqual(connection);
+    expect(state.connectionTestStatus).toBe('none');
+  });
+
+  it('sets success status', () => {
+    let state = connectionsFeature.reducer(initialState, Actions.checkConnection({ connection }));
+    state = connectionsFeature.reducer(state, InternalActions.connectionCheckedSuccessfully({ connection }));
+    expect(state.connectionTestStatus).toBe('success');
+  });
+
+  it('sets error status', () => {
+    let state = connectionsFeature.reducer(initialState, Actions.checkConnection({ connection }));
+    state = connectionsFeature.reducer(state, InternalActions.connectionCheckFailed({ connection }));
+    expect(state.connectionTestStatus).toBe('error');
+  });
+});

--- a/libs/logs/components/src/lib/log-line/log-line.component.spec.ts
+++ b/libs/logs/components/src/lib/log-line/log-line.component.spec.ts
@@ -1,0 +1,59 @@
+import { Component } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { LogLineComponent } from './log-line.component';
+import { LogLine } from '@service-bus-browser/logs-contracts';
+
+@Component({
+  template: `<sbb-logs-log-line [logLine]="log"></sbb-logs-log-line>`,
+  standalone: true,
+  imports: [LogLineComponent]
+})
+class HostComponent {
+  log: LogLine = { severity: 'info', message: 'msg', loggedAt: new Date() };
+}
+
+describe('LogLineComponent', () => {
+  let host: HostComponent;
+  let fixture: ComponentFixture<HostComponent>;
+  let component: LogLineComponent;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [HostComponent]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(HostComponent);
+    host = fixture.componentInstance;
+    component = fixture.debugElement.children[0].componentInstance;
+  });
+
+  it('returns correct color for info', () => {
+    host.log = { ...host.log, severity: 'info' };
+    fixture.detectChanges();
+    expect(component.logLineColor()).toBe('var(--p-blue-400)');
+  });
+
+  it('returns correct color for warn', () => {
+    host.log = { ...host.log, severity: 'warn' };
+    fixture.detectChanges();
+    expect(component.logLineColor()).toBe('var(--p-amber-500)');
+  });
+
+  it('returns correct color for error', () => {
+    host.log = { ...host.log, severity: 'error' };
+    fixture.detectChanges();
+    expect(component.logLineColor()).toBe('var(--p-red-400)');
+  });
+
+  it('returns correct color for critical', () => {
+    host.log = { ...host.log, severity: 'critical' };
+    fixture.detectChanges();
+    expect(component.logLineColor()).toBe('var(--p-red-900)');
+  });
+
+  it('returns default color otherwise', () => {
+    host.log = { ...host.log, severity: 'verbose' };
+    fixture.detectChanges();
+    expect(component.logLineColor()).toBe('var(--p-slate-400)');
+  });
+});

--- a/libs/logs/services/src/lib/logger.spec.ts
+++ b/libs/logs/services/src/lib/logger.spec.ts
@@ -1,0 +1,23 @@
+import { TestBed } from '@angular/core/testing';
+import { provideMockStore, MockStore } from '@ngrx/store/testing';
+import { Logger } from './logger';
+import { LogsActions } from '@service-bus-browser/logs-store';
+
+describe('Logger', () => {
+  let store: MockStore;
+  let logger: Logger;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [Logger, provideMockStore({})]
+    });
+    store = TestBed.inject(MockStore);
+    logger = TestBed.inject(Logger);
+  });
+
+  it('dispatches writeLog action', () => {
+    const spy = jest.spyOn(store, 'dispatch');
+    logger.info('hello');
+    expect(spy).toHaveBeenCalledWith(LogsActions.writeLog({ message: 'hello', severity: 'info', context: undefined }));
+  });
+});

--- a/libs/logs/store/src/lib/logs.store.spec.ts
+++ b/libs/logs/store/src/lib/logs.store.spec.ts
@@ -1,0 +1,10 @@
+import { logsReducer, initialState } from './logs.store';
+import { writeLog } from './logs.actions';
+
+describe('logsReducer', () => {
+  it('should add a log entry', () => {
+    const state = logsReducer(initialState, writeLog({ severity: 'info', message: 'test', context: { a: 1 } }));
+    expect(state.logs.length).toBe(1);
+    expect(state.logs[0]).toMatchObject({ severity: 'info', message: 'test', context: { a: 1 } });
+  });
+});

--- a/libs/shared/components/src/lib/context-menu/context-menu.component.spec.ts
+++ b/libs/shared/components/src/lib/context-menu/context-menu.component.spec.ts
@@ -1,0 +1,47 @@
+import { Component } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ContextMenuComponent } from './context-menu.component';
+import { SbbMenuItem } from '@service-bus-browser/shared-contracts';
+
+@Component({
+  template: `<sbb-context-menu [data]="data" [target]="target" [model]="items"></sbb-context-menu>`,
+  standalone: true,
+  imports: [ContextMenuComponent]
+})
+class HostComponent {
+  data: any = {};
+  target = document.createElement('div');
+  items: SbbMenuItem<any>[] = [];
+}
+
+describe('ContextMenuComponent', () => {
+  let host: HostComponent;
+  let fixture: ComponentFixture<HostComponent>;
+  let component: ContextMenuComponent<any>;
+
+  beforeEach(async () => {
+    (window as any).matchMedia = (query: string) => ({
+      matches: false,
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn()
+    });
+    await TestBed.configureTestingModule({
+      imports: [HostComponent]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(HostComponent);
+    host = fixture.componentInstance;
+    component = fixture.debugElement.children[0].componentInstance;
+  });
+
+  it('wraps menu item commands', () => {
+    const spy = jest.fn();
+    host.data = { id: 1 };
+    host.items = [{ label: 'test', onSelect: spy }];
+    fixture.detectChanges();
+
+    const menuItems = component.contextMenuItems();
+    menuItems[0].command!({} as any);
+    expect(spy).toHaveBeenCalledWith(host.data, expect.anything());
+  });
+});

--- a/libs/shared/services/src/lib/theme.service.spec.ts
+++ b/libs/shared/services/src/lib/theme.service.spec.ts
@@ -1,0 +1,48 @@
+import { TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { ColorThemeService } from './theme.service';
+
+function mockMatchMedia(matches: boolean) {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: jest.fn().mockImplementation(() => ({
+      matches,
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn()
+    }))
+  });
+}
+
+describe('ColorThemeService', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    TestBed.configureTestingModule({});
+  });
+
+  it('initializes preference from localStorage', () => {
+    localStorage.setItem('color-theme-preference', 'dark');
+    mockMatchMedia(false);
+    const service = TestBed.runInInjectionContext(() => new ColorThemeService());
+    expect(service.preference()).toBe('dark');
+  });
+
+  it('stores preference changes to localStorage', fakeAsync(() => {
+    mockMatchMedia(false);
+    const service = TestBed.runInInjectionContext(() => new ColorThemeService());
+    service.setPreference('light');
+    tick();
+    expect(localStorage.getItem('color-theme-preference')).toBe('light');
+  }));
+
+  it('uses os mode when preference is sync', () => {
+    mockMatchMedia(true);
+    const service = TestBed.runInInjectionContext(() => new ColorThemeService());
+    expect(service.mode()).toBe('dark');
+  });
+
+  it('honors explicit preference over os mode', () => {
+    mockMatchMedia(true);
+    const service = TestBed.runInInjectionContext(() => new ColorThemeService());
+    service.setPreference('light');
+    expect(service.mode()).toBe('light');
+  });
+});

--- a/libs/tasks/store/src/lib/tasks.store.spec.ts
+++ b/libs/tasks/store/src/lib/tasks.store.spec.ts
@@ -1,0 +1,22 @@
+import { reducer, initialState } from './tasks.store';
+import * as Actions from './tasks.actions';
+
+describe('tasks reducer', () => {
+  it('creates a new task', () => {
+    const state = reducer(initialState, Actions.createTask({ id: '1', description: 'Test' }));
+    expect(state.tasks.length).toBe(1);
+    expect(state.tasks[0]).toMatchObject({ id: '1', description: 'Test', status: 'in-progress', progress: 0 });
+  });
+
+  it('updates progress of a task', () => {
+    let state = reducer(initialState, Actions.createTask({ id: '1', description: 'Test', hasProgress: true }));
+    state = reducer(state, Actions.setProgress({ id: '1', progress: 50 }));
+    expect(state.tasks[0].progress).toBe(50);
+  });
+
+  it('completes a task', () => {
+    let state = reducer(initialState, Actions.createTask({ id: '1', description: 'Test' }));
+    state = reducer(state, Actions.completeTask({ id: '1' }));
+    expect(state.tasks.length).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for color theme service
- add context menu and log line component tests
- cover logs reducer, tasks reducer, and connections reducer
- test logger service dispatch behavior

## Testing
- `npx nx run-many --target=test --all --skip-nx-cache`

------
https://chatgpt.com/codex/tasks/task_e_684efb143e788329be8af2e2cb19bbe0