### PR TITLE
Fix 'peek' typo in message actions

### DIFF
--- a/apps/servicebus-browser-frontend/src/app/ngrx/router.effects.ts
+++ b/apps/servicebus-browser-frontend/src/app/ngrx/router.effects.ts
@@ -12,7 +12,7 @@ export class RouterEffects {
   router = inject(Router);
 
   navigateTo$ = createEffect(() => this.actions.pipe(
-    ofType(MessagesActions.peakMessagesLoadingDone),
+    ofType(MessagesActions.peekMessagesLoadingDone),
     switchMap(({ pageId }) => from(this.router.navigate([
       'messages',
       'page',

--- a/apps/servicebus-browser-frontend/src/app/sidebar/sidebar.component.ts
+++ b/apps/servicebus-browser-frontend/src/app/sidebar/sidebar.component.ts
@@ -146,7 +146,7 @@ export class SidebarComponent {
 
   queueContextMenuItems: SbbMenuItem<QueueWithMetaData>[] = [
     {
-      label: 'Peak messages',
+      label: 'Peek messages',
       icon: 'pi pi-download',
       supportedMultiSelection: false,
       onSelect: async (
@@ -161,7 +161,7 @@ export class SidebarComponent {
       },
     },
     {
-      label: 'Peak deadletter messages',
+      label: 'Peek deadletter messages',
       icon: 'pi pi-download',
       supportedMultiSelection: false,
       onSelect: async (
@@ -176,7 +176,7 @@ export class SidebarComponent {
       },
     },
     {
-      label: 'Peak transfer deadletter messages',
+      label: 'Peek transfer deadletter messages',
       icon: 'pi pi-download',
       supportedMultiSelection: false,
       onSelect: async (
@@ -360,7 +360,7 @@ export class SidebarComponent {
 
   subscriptionContextMenuItems: SbbMenuItem<SubscriptionWithMetaData>[] = [
     {
-      label: 'Peak messages',
+      label: 'Peek messages',
       icon: 'pi pi-download',
       supportedMultiSelection: false,
       onSelect: async (
@@ -376,7 +376,7 @@ export class SidebarComponent {
       },
     },
     {
-      label: 'Peak deadletter messages',
+      label: 'Peek deadletter messages',
       icon: 'pi pi-download',
       supportedMultiSelection: false,
       onSelect: async (
@@ -392,7 +392,7 @@ export class SidebarComponent {
       },
     },
     {
-      label: 'Peak transfer deadletter messages',
+      label: 'Peek transfer deadletter messages',
       icon: 'pi pi-download',
       supportedMultiSelection: false,
       onSelect: async (
@@ -672,7 +672,7 @@ export class SidebarComponent {
     }
 
     this.store.dispatch(
-      MessagesActions.peakMessages({
+      MessagesActions.peekMessages({
         endpoint: currentEndpoint,
         maxAmount: this.maxAmount(),
         fromSequenceNumber: this.fromSequenceNumber().toString(),

--- a/libs/messages/store/src/lib/messages-logs.effects.ts
+++ b/libs/messages/store/src/lib/messages-logs.effects.ts
@@ -16,14 +16,14 @@ export class MessagesLogsEffects {
   store = inject(Store);
 
   logLoadingProgress$ = createEffect(() => this.actions.pipe(
-    ofType(internalActions.peakMessagesPartLoaded),
+    ofType(internalActions.peekMessagesPartLoaded),
     tap(({ endpoint, maxAmount, amountLoaded }) => {
       this.logger.info(`Loaded ${amountLoaded} of ${maxAmount + amountLoaded} messages from ${'queueName' in endpoint ? endpoint.queueName : endpoint.subscriptionName}`);
     })
   ), { dispatch: false });
 
   logLoadingDone$ = createEffect(() => this.actions.pipe(
-    ofType(actions.peakMessagesLoadingDone),
+    ofType(actions.peekMessagesLoadingDone),
     tap(({ endpoint }) => {
       this.logger.info(`Finished loading messages from ${'queueName' in endpoint ? endpoint.queueName : endpoint.subscriptionName}`);
     })

--- a/libs/messages/store/src/lib/messages-tasks.effects.ts
+++ b/libs/messages/store/src/lib/messages-tasks.effects.ts
@@ -13,7 +13,7 @@ export class MessagesTasksEffects {
   actions = inject(Actions);
 
   createTask$ = createEffect(() => this.actions.pipe(
-    ofType(internalActions.peakMessagesLoad),
+    ofType(internalActions.peekMessagesLoad),
     map(({ pageId, maxAmount, endpoint }) => {
       const endpointName = 'queueName' in endpoint
         ? endpoint.queueName
@@ -30,7 +30,7 @@ export class MessagesTasksEffects {
   ));
 
   updateTaskProgress$ = createEffect(() => this.actions.pipe(
-    ofType(internalActions.peakMessagesPartLoaded),
+    ofType(internalActions.peekMessagesPartLoaded),
     map(({ pageId, maxAmount, amountLoaded }) => TasksActions.setProgress({
       id: pageId,
       statusDescription: `${amountLoaded}/${maxAmount + amountLoaded}`,
@@ -39,7 +39,7 @@ export class MessagesTasksEffects {
   ));
 
   completeTask$ = createEffect(() => this.actions.pipe(
-    ofType(actions.peakMessagesLoadingDone),
+    ofType(actions.peekMessagesLoadingDone),
     map(({ pageId }) => TasksActions.completeTask({ id: pageId })),
   ));
 

--- a/libs/messages/store/src/lib/messages.actions.ts
+++ b/libs/messages/store/src/lib/messages.actions.ts
@@ -3,8 +3,8 @@ import { UUID } from '@service-bus-browser/shared-contracts';
 import { ReceiveEndpoint, SendEndpoint } from '@service-bus-browser/service-bus-contracts';
 import { ServiceBusMessage, ServiceBusReceivedMessage } from '@service-bus-browser/messages-contracts';
 
-export const peakMessages = createAction(
-  '[Messages] peak messages',
+export const peekMessages = createAction(
+  '[Messages] peek messages',
   props<{
     endpoint: ReceiveEndpoint,
     maxAmount: number,
@@ -19,8 +19,8 @@ export const closePage = createAction(
   }>()
 )
 
-export const peakMessagesLoadingDone = createAction(
-  '[Messages] peak messages finished loading',
+export const peekMessagesLoadingDone = createAction(
+  '[Messages] peek messages finished loading',
   props<{
     pageId: UUID,
     endpoint: ReceiveEndpoint,

--- a/libs/messages/store/src/lib/messages.effects.ts
+++ b/libs/messages/store/src/lib/messages.effects.ts
@@ -21,9 +21,9 @@ export class MessagesEffects {
 
   currentState = this.store.selectSignal(featureSelector);
 
-  loadPeakQueueMessages$ = createEffect(() => this.actions$.pipe(
-    ofType(actions.peakMessages),
-    map(({ endpoint, maxAmount, fromSequenceNumber }) => internalActions.peakMessagesLoad({
+  loadPeekQueueMessages$ = createEffect(() => this.actions$.pipe(
+    ofType(actions.peekMessages),
+    map(({ endpoint, maxAmount, fromSequenceNumber }) => internalActions.peekMessagesLoad({
       pageId: crypto.randomUUID(),
       endpoint,
       maxAmount,
@@ -32,17 +32,17 @@ export class MessagesEffects {
     }))
   ));
 
-  loadPeakQueueMessagesPart$ = createEffect(() => this.actions$.pipe(
-    ofType(internalActions.peakMessagesLoad),
+  loadPeekQueueMessagesPart$ = createEffect(() => this.actions$.pipe(
+    ofType(internalActions.peekMessagesLoad),
     mergeMap(({ pageId, endpoint, maxAmount, fromSequenceNumber, alreadyLoadedAmount }) => {
       const maxAmountToLoad = Math.min(maxAmount, this.MAX_PAGE_SIZE);
 
-      const messages$ =  from(this.messagesService.peakMessages(
+      const messages$ =  from(this.messagesService.peekMessages(
         endpoint, maxAmountToLoad, Long.fromString(fromSequenceNumber)));
 
       return messages$
         .pipe(
-          map(messages => internalActions.peakMessagesPartLoaded({
+          map(messages => internalActions.peekMessagesPartLoaded({
               pageId,
               endpoint,
               maxAmount: maxAmount - messages.length,
@@ -54,10 +54,10 @@ export class MessagesEffects {
   ));
 
   loadMoreMessages$ = createEffect(() => this.actions$.pipe(
-    ofType(internalActions.peakMessagesPartLoaded),
+    ofType(internalActions.peekMessagesPartLoaded),
     map(({ pageId, endpoint, maxAmount, messages, amountLoaded }) => {
       if (maxAmount <= 0 || messages.length === 0) {
-        return actions.peakMessagesLoadingDone({ pageId, endpoint });
+        return actions.peekMessagesLoadingDone({ pageId, endpoint });
       }
 
       const sequenceNumbers = messages.map(m => Long.fromString(m.sequenceNumber ?? '0'));
@@ -69,7 +69,7 @@ export class MessagesEffects {
 
       const fromSequenceNumber = highestSequenceNumber.add(1).toString();
 
-      return internalActions.peakMessagesLoad({
+      return internalActions.peekMessagesLoad({
         pageId,
         endpoint,
         maxAmount,

--- a/libs/messages/store/src/lib/messages.internal-actions.ts
+++ b/libs/messages/store/src/lib/messages.internal-actions.ts
@@ -3,8 +3,8 @@ import { UUID } from '@service-bus-browser/shared-contracts';
 import { ServiceBusMessage, ServiceBusReceivedMessage } from '@service-bus-browser/messages-contracts';
 import { ReceiveEndpoint, SendEndpoint } from '@service-bus-browser/service-bus-contracts';
 
-export const peakMessagesLoad = createAction(
-  '[Messages] load peak messages',
+export const peekMessagesLoad = createAction(
+  '[Messages] load peek messages',
   props<{
     pageId: UUID,
     endpoint: ReceiveEndpoint,
@@ -14,8 +14,8 @@ export const peakMessagesLoad = createAction(
   }>()
 )
 
-export const peakMessagesPartLoaded = createAction(
-  '[Messages] peak messages partially loaded',
+export const peekMessagesPartLoaded = createAction(
+  '[Messages] peek messages partially loaded',
   props<{
     pageId: UUID,
     endpoint: ReceiveEndpoint,

--- a/libs/messages/store/src/lib/messages.store.ts
+++ b/libs/messages/store/src/lib/messages.store.ts
@@ -18,7 +18,7 @@ export const initialState: MessagesState = {
 
 export const logsReducer = createReducer(
   initialState,
-  on(internalActions.peakMessagesLoad, (state, { pageId, endpoint }): MessagesState => {
+  on(internalActions.peekMessagesLoad, (state, { pageId, endpoint }): MessagesState => {
     const page = state.receivedMessages.find(page => page.id === pageId);
     if (page) {
       return state;
@@ -43,7 +43,7 @@ export const logsReducer = createReducer(
       ]
     }
   }),
-  on(internalActions.peakMessagesPartLoaded, (state, { pageId, messages }): MessagesState => {
+  on(internalActions.peekMessagesPartLoaded, (state, { pageId, messages }): MessagesState => {
     const page = state.receivedMessages.find(page => page.id === pageId);
     if (!page) {
       return state;
@@ -57,7 +57,7 @@ export const logsReducer = createReducer(
         ] } : page)
     };
   }),
-  on(actions.peakMessagesLoadingDone, (state, { pageId }): MessagesState => {
+  on(actions.peekMessagesLoadingDone, (state, { pageId }): MessagesState => {
 
     return {
       ...state,

--- a/libs/service-bus/clients/src/lib/message-receive-client.ts
+++ b/libs/service-bus/clients/src/lib/message-receive-client.ts
@@ -14,7 +14,7 @@ export class MessageReceiveClient {
   constructor(private connection: Connection, private endpoint: ReceiveEndpoint)
   {}
 
-  async peakMessages(maxMessageCount: number, fromSequenceNumber?: Long) {
+  async peekMessages(maxMessageCount: number, fromSequenceNumber?: Long) {
     const receiver = this.getReceiver('peekLock');
     const messages = await receiver.peekMessages(maxMessageCount, {
       fromSequenceNumber: fromSequenceNumber ?? Long.fromNumber(0)

--- a/libs/service-bus/electron-client/src/lib/service-bus-messages-electron-client.ts
+++ b/libs/service-bus/electron-client/src/lib/service-bus-messages-electron-client.ts
@@ -15,12 +15,12 @@ const typelessWindow = window as unknown;
 const { serviceBusApi } = typelessWindow as ElectronWindow;
 
 export class ServiceBusMessagesElectronClient {
-  async peakMessages(
+  async peekMessages(
     endpoint: ReceiveEndpoint,
     maxMessageCount: number,
     fromSequenceNumber?: Long
   ) {
-    return (await serviceBusApi.messagesDoRequest('peakMessages', {
+    return (await serviceBusApi.messagesDoRequest('peekMessages', {
       endpoint,
       maxMessageCount,
       fromSequenceNumber: fromSequenceNumber?.toString(),

--- a/libs/service-bus/server/src/lib/receive-messages-actions.ts
+++ b/libs/service-bus/server/src/lib/receive-messages-actions.ts
@@ -10,7 +10,7 @@ const getReceiveClient = (receiveEndpoint: ReceiveEndpoint, connectionManager: C
     .getMessageReceiveClient(receiveEndpoint);
 }
 
-export const peakMessages = (body: {
+export const peekMessages = (body: {
   endpoint: ReceiveEndpoint,
   maxMessageCount: number,
   fromSequenceNumber?: string,
@@ -18,7 +18,7 @@ export const peakMessages = (body: {
   const receiveClient = getReceiveClient(body.endpoint, connectionManager);
 
   const fromSequenceNumber = body.fromSequenceNumber ? Long.fromString(body.fromSequenceNumber) : undefined;
-  return receiveClient.peakMessages(body.maxMessageCount, fromSequenceNumber);
+  return receiveClient.peekMessages(body.maxMessageCount, fromSequenceNumber);
 }
 
 export const receiveMessages = (body: {


### PR DESCRIPTION
## Summary
- fix inconsistent naming of peek message actions and effects
- rename server/client functions from `peak` to `peek`
- update component labels and dispatches

## Testing
- `npx nx run-many --target=lint --all`
- `npx nx run-many --target=test --all`

------
https://chatgpt.com/codex/tasks/task_e_684f0aeb8c8c8329800e0c1b7866126b