### PR TITLE
Add messages-store unit tests

### DIFF
--- a/libs/messages/store/src/lib/messages-logs.effects.spec.ts
+++ b/libs/messages/store/src/lib/messages-logs.effects.spec.ts
@@ -1,0 +1,44 @@
+import { TestBed } from '@angular/core/testing';
+import { provideMockActions } from '@ngrx/effects/testing';
+import { provideMockStore } from '@ngrx/store/testing';
+import { ReplaySubject } from 'rxjs';
+import { MessagesLogsEffects } from './messages-logs.effects';
+import { Logger } from '@service-bus-browser/logs-services';
+import * as internalActions from './messages.internal-actions';
+import * as actions from './messages.actions';
+import { ReceiveEndpoint } from '@service-bus-browser/service-bus-contracts';
+
+const endpoint: ReceiveEndpoint = { connectionId: '00000000-0000-0000-0000-000000000001', queueName: 'q', channel: undefined };
+
+describe('MessagesLogsEffects', () => {
+  let effects: MessagesLogsEffects;
+  let actions$: ReplaySubject<any>;
+  let logger: { info: jest.Mock, error: jest.Mock };
+
+  beforeEach(() => {
+    logger = { info: jest.fn(), error: jest.fn() };
+    TestBed.configureTestingModule({
+      providers: [
+        MessagesLogsEffects,
+        provideMockStore({}),
+        { provide: Logger, useValue: logger },
+        provideMockActions(() => actions$)
+      ]
+    });
+    effects = TestBed.inject(MessagesLogsEffects);
+  });
+
+  it('logs progress', () => {
+    actions$ = new ReplaySubject(1);
+    actions$.next(internalActions.peekMessagesPartLoaded({ pageId: '00000000-0000-0000-0000-000000000002', endpoint, maxAmount: 5, amountLoaded: 1, messages: [] }));
+    effects.logLoadingProgress$.subscribe();
+    expect(logger.info).toHaveBeenCalled();
+  });
+
+  it('logs cleared', () => {
+    actions$ = new ReplaySubject(1);
+    actions$.next(actions.clearedEndpoint({ endpoint }));
+    effects.logClearedEndpoint$.subscribe();
+    expect(logger.info).toHaveBeenCalled();
+  });
+});

--- a/libs/messages/store/src/lib/messages-tasks.effects.spec.ts
+++ b/libs/messages/store/src/lib/messages-tasks.effects.spec.ts
@@ -1,0 +1,34 @@
+import { TestBed } from '@angular/core/testing';
+import { provideMockActions } from '@ngrx/effects/testing';
+import { ReplaySubject, firstValueFrom } from 'rxjs';
+import { MessagesTasksEffects } from './messages-tasks.effects';
+import * as internalActions from './messages.internal-actions';
+import { ReceiveEndpoint } from '@service-bus-browser/service-bus-contracts';
+import { TasksActions } from '@service-bus-browser/tasks-store';
+
+const endpoint: ReceiveEndpoint = { connectionId: '00000000-0000-0000-0000-000000000001', queueName: 'q', channel: undefined };
+
+describe('MessagesTasksEffects', () => {
+  let actions$: ReplaySubject<any>;
+  let effects: MessagesTasksEffects;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [MessagesTasksEffects, provideMockActions(() => actions$)]
+    });
+    effects = TestBed.inject(MessagesTasksEffects);
+  });
+
+  it('creates task on load', async () => {
+    actions$ = new ReplaySubject(1);
+    actions$.next(internalActions.peekMessagesLoad({ pageId: '00000000-0000-0000-0000-000000000002', endpoint, maxAmount: 5, alreadyLoadedAmount: 0, fromSequenceNumber: '0' }));
+    const result = await firstValueFrom(effects.createTask$);
+    expect(result).toEqual(TasksActions.createTask({
+      id: '00000000-0000-0000-0000-000000000002',
+      statusDescription: '0/5',
+      description: 'loading messages from q',
+      hasProgress: true,
+      initialProgress: 0
+    }));
+  });
+});

--- a/libs/messages/store/src/lib/messages-toasts.effects.spec.ts
+++ b/libs/messages/store/src/lib/messages-toasts.effects.spec.ts
@@ -1,0 +1,43 @@
+import { TestBed } from '@angular/core/testing';
+import { provideMockActions } from '@ngrx/effects/testing';
+import { ReplaySubject } from 'rxjs';
+import { MessagesToastsEffects } from './messages-toasts.effects';
+import * as internalActions from './messages.internal-actions';
+import { MessageService } from 'primeng/api';
+import { SendEndpoint } from '@service-bus-browser/service-bus-contracts';
+
+const endpoint: SendEndpoint = { connectionId: '00000000-0000-0000-0000-000000000001', queueName: 'q', endpoint: '', endpointDisplay: '' };
+
+const message = { body: 'a' } as any;
+
+describe('MessagesToastsEffects', () => {
+  let actions$: ReplaySubject<any>;
+  let effects: MessagesToastsEffects;
+  let service: { add: jest.Mock };
+
+  beforeEach(() => {
+    service = { add: jest.fn() };
+    TestBed.configureTestingModule({
+      providers: [
+        MessagesToastsEffects,
+        { provide: MessageService, useValue: service },
+        provideMockActions(() => actions$)
+      ]
+    });
+    effects = TestBed.inject(MessagesToastsEffects);
+  });
+
+  it('shows success toast', () => {
+    actions$ = new ReplaySubject(1);
+    actions$.next(internalActions.sendedMessage({ endpoint, message }));
+    effects.showMessageSendSuccess$.subscribe();
+    expect(service.add).toHaveBeenCalled();
+  });
+
+  it('shows error toast', () => {
+    actions$ = new ReplaySubject(1);
+    actions$.next(internalActions.messageSendFailed({ endpoint, message }));
+    effects.showMessageSendFailed$.subscribe();
+    expect(service.add).toHaveBeenCalled();
+  });
+});

--- a/libs/messages/store/src/lib/messages.effects.spec.ts
+++ b/libs/messages/store/src/lib/messages.effects.spec.ts
@@ -1,0 +1,71 @@
+import { TestBed } from '@angular/core/testing';
+import { provideMockActions } from '@ngrx/effects/testing';
+import { provideMockStore } from '@ngrx/store/testing';
+import { ReplaySubject, firstValueFrom } from 'rxjs';
+import { MessagesEffects } from './messages.effects';
+import * as actions from './messages.actions';
+import * as internalActions from './messages.internal-actions';
+import { ServiceBusMessagesElectronClient } from '@service-bus-browser/service-bus-electron-client';
+import { ReceiveEndpoint, SendEndpoint } from '@service-bus-browser/service-bus-contracts';
+
+const endpoint: ReceiveEndpoint & SendEndpoint = {
+  connectionId: "00000000-0000-0000-0000-000000000001",
+  queueName: 'test-queue',
+  channel: undefined as any,
+  endpoint: "",
+  endpointDisplay: ""
+};
+
+const message = { body: 'a' } as any;
+
+describe('MessagesEffects', () => {
+  let actions$: ReplaySubject<any>;
+  let effects: MessagesEffects;
+  let service: { sendMessage: jest.Mock };
+
+  beforeEach(() => {
+    Object.defineProperty(globalThis, 'crypto', {
+      value: { randomUUID: () => '00000000-0000-0000-0000-000000000002' },
+      configurable: true
+    });
+    service = { sendMessage: jest.fn() };
+    TestBed.configureTestingModule({
+      providers: [
+        MessagesEffects,
+        provideMockStore({}),
+        { provide: ServiceBusMessagesElectronClient, useValue: service },
+        provideMockActions(() => actions$)
+      ]
+    });
+    effects = TestBed.inject(MessagesEffects);
+  });
+
+  it('loads peek messages', async () => {
+    actions$ = new ReplaySubject(1);
+    actions$.next(actions.peekMessages({ endpoint, maxAmount: 5 }));
+    const result = await firstValueFrom(effects.loadPeekQueueMessages$);
+    expect(result).toEqual(internalActions.peekMessagesLoad({
+      pageId: '00000000-0000-0000-0000-000000000002',
+      endpoint,
+      maxAmount: 5,
+      alreadyLoadedAmount: 0,
+      fromSequenceNumber: '0'
+    }));
+  });
+
+  it('emits send success', async () => {
+    service.sendMessage.mockResolvedValue(undefined);
+    actions$ = new ReplaySubject(1);
+    actions$.next(actions.sendMessage({ endpoint, message }));
+    const result = await firstValueFrom(effects.sendMessage$);
+    expect(result).toEqual(internalActions.sendedMessage({ endpoint, message }));
+  });
+
+  it('emits send failed', async () => {
+    service.sendMessage.mockRejectedValue(new Error('fail'));
+    actions$ = new ReplaySubject(1);
+    actions$.next(actions.sendMessage({ endpoint, message }));
+    const result = await firstValueFrom(effects.sendMessage$);
+    expect(result).toEqual(internalActions.messageSendFailed({ endpoint, message }));
+  });
+});

--- a/libs/messages/store/src/lib/messages.store.spec.ts
+++ b/libs/messages/store/src/lib/messages.store.spec.ts
@@ -1,0 +1,102 @@
+import { logsReducer, initialState } from './messages.store';
+import * as Actions from './messages.actions';
+import * as InternalActions from './messages.internal-actions';
+import { ReceiveEndpoint } from '@service-bus-browser/service-bus-contracts';
+import { ServiceBusReceivedMessage } from '@service-bus-browser/messages-contracts';
+import { UUID } from '@service-bus-browser/shared-contracts';
+import { randomUUID } from 'crypto';
+
+const connectionId: UUID = '00000000-0000-0000-0000-000000000001';
+const endpoint: ReceiveEndpoint = {
+  connectionId,
+  queueName: 'test-queue',
+  channel: undefined
+};
+
+const pageId: UUID = '11111111-1111-1111-1111-111111111111';
+
+const loadAction = (id: UUID = pageId) =>
+  InternalActions.peekMessagesLoad({
+    pageId: id,
+    endpoint,
+    maxAmount: 10,
+    alreadyLoadedAmount: 0,
+    fromSequenceNumber: '0'
+  });
+
+const partLoadedAction = (id: UUID = pageId, messages: ServiceBusReceivedMessage[]) =>
+  InternalActions.peekMessagesPartLoaded({
+    pageId: id,
+    endpoint,
+    maxAmount: 10,
+    amountLoaded: messages.length,
+    messages
+  });
+
+describe('messages store reducer', () => {
+  beforeAll(() => {
+    Object.defineProperty(globalThis, 'crypto', {
+      value: { randomUUID },
+      configurable: true
+    });
+  });
+  it('creates a new page when loading messages', () => {
+    const state = logsReducer(initialState, loadAction());
+    expect(state.receivedMessages.length).toBe(1);
+    expect(state.receivedMessages[0]).toMatchObject({
+      id: pageId,
+      name: 'test-queue (loading...)',
+      loaded: false,
+      messages: []
+    });
+  });
+
+  it('does not duplicate existing page', () => {
+    const withPage = logsReducer(initialState, loadAction());
+    const state = logsReducer(withPage, loadAction());
+    expect(state.receivedMessages.length).toBe(1);
+  });
+
+  it('appends messages when part loaded', () => {
+    let state = logsReducer(initialState, loadAction());
+    const msgs: ServiceBusReceivedMessage[] = [
+      { body: 'a', sequenceNumber: '1', state: 'active' },
+      { body: 'b', sequenceNumber: '2', state: 'active' }
+    ];
+    state = logsReducer(state, partLoadedAction(pageId, msgs));
+    expect(state.receivedMessages[0].messages.length).toBe(2);
+  });
+
+  it('marks page loaded and sets name range', () => {
+    let state = logsReducer(initialState, loadAction());
+    const msgs: ServiceBusReceivedMessage[] = [
+      { body: 'a', sequenceNumber: '1', state: 'active' },
+      { body: 'b', sequenceNumber: '2', state: 'active' }
+    ];
+    state = logsReducer(state, partLoadedAction(pageId, msgs));
+    state = logsReducer(state, Actions.peekMessagesLoadingDone({ pageId, endpoint }));
+    expect(state.receivedMessages[0].loaded).toBe(true);
+    expect(state.receivedMessages[0].name).toBe('test-queue (1 - 2)');
+  });
+
+  it('removes page when closed', () => {
+    let state = logsReducer(initialState, loadAction());
+    state = logsReducer(state, Actions.closePage({ pageId }));
+    expect(state.receivedMessages.length).toBe(0);
+  });
+
+  it('adds page for imported messages', () => {
+    const msgs: ServiceBusReceivedMessage[] = [{ body: 'a', sequenceNumber: '1', state: 'active' }];
+    const state = logsReducer(initialState, InternalActions.messagesImported({ pageName: 'file', messages: msgs }));
+    expect(state.receivedMessages.length).toBe(1);
+    expect(state.receivedMessages[0].name).toBe('Imported: file');
+    expect(state.receivedMessages[0].loaded).toBe(true);
+    expect(state.receivedMessages[0].messages).toEqual(msgs);
+  });
+
+  it('sets batch resend messages', () => {
+    const msgs: ServiceBusReceivedMessage[] = [{ body: 'a', sequenceNumber: '1', state: 'active' }];
+    const state = logsReducer(initialState, Actions.setBatchResendMessages({ messages: msgs }));
+    expect(state.messageForBatchResend).toEqual(msgs);
+  });
+});


### PR DESCRIPTION
## Summary
- add reducer tests for messages-store
- test effects for messages store

## Testing
- `pnpm exec nx run @service-bus-browser/messages-store:test --configuration ci -- --runInBand`
- `pnpm exec nx run-many --target test --all --configuration ci -- --coverageReporters=text-summary`

------
https://chatgpt.com/codex/tasks/task_e_684fd10dfd58832997799cef1ce01f5a