### PR TITLE
feat(page-navigator): add close-multiple options to tab context menu

### DIFF
--- a/libs/main-ui/src/lib/ngrx/page.effects.ts
+++ b/libs/main-ui/src/lib/ngrx/page.effects.ts
@@ -3,7 +3,7 @@ import { Actions, createEffect, ofType, OnInitEffects } from '@ngrx/effects';
 import { pagesActions } from './route.actions';
 import { Action, Store } from '@ngrx/store';
 import { featureSelector, selectPages } from './route.selectors';
-import { switchMap, tap } from 'rxjs';
+import { mergeMap, tap } from 'rxjs';
 import {
   messagePagesActions,
 } from '@service-bus-browser/messages-store';
@@ -32,7 +32,7 @@ export class PageEffects implements OnInitEffects {
   closeMessagePage$ = createEffect(() =>
     this.actions.pipe(
       ofType(pagesActions.closePage),
-      switchMap(({ id }) => {
+      mergeMap(({ id }) => {
         const page = this.pages().find((page) => page.id === id);
         switch (page?.type) {
           case 'messages':

--- a/libs/main-ui/src/lib/page-navigator/page-navigator.ts
+++ b/libs/main-ui/src/lib/page-navigator/page-navigator.ts
@@ -69,6 +69,7 @@ export class PageNavigator {
     event.preventDefault();
     this.contextMenuPageId.set(pageId);
     this.contextMenuPageIndex.set(index);
+    const pageCount = this.pages().length;
     this.contextMenuItems.set([
       {
         label: 'Rename',
@@ -80,8 +81,40 @@ export class PageNavigator {
         icon: 'pi pi-times',
         command: () => this.store.dispatch(pagesActions.closePage({ id: pageId, position: index })),
       },
+      {
+        separator: true,
+      },
+      {
+        label: 'Close tabs to the left',
+        icon: 'pi pi-angle-double-left',
+        disabled: index === 0,
+        command: () => this.closePagesInRange(0, index - 1),
+      },
+      {
+        label: 'Close tabs to the right',
+        icon: 'pi pi-angle-double-right',
+        disabled: index >= pageCount - 1,
+        command: () => this.closePagesInRange(index + 1, pageCount - 1),
+      },
+      {
+        label: 'Close all tabs',
+        icon: 'pi pi-times-circle',
+        disabled: pageCount === 0,
+        command: () => this.closePagesInRange(0, pageCount - 1),
+      },
     ]);
     this.contextMenuRef()?.show(event);
+  }
+
+  private closePagesInRange(fromIndex: number, toIndex: number) {
+    const pages = this.pages();
+    for (let i = toIndex; i >= fromIndex; i--) {
+      const page = pages[i];
+      if (!page) {
+        continue;
+      }
+      this.store.dispatch(pagesActions.closePage({ id: page.id, position: i }));
+    }
   }
 
   closePage(pageId: UUID, event: Event, index: number) {

--- a/libs/messages/store/src/lib/messages-db.effects.ts
+++ b/libs/messages/store/src/lib/messages-db.effects.ts
@@ -42,7 +42,7 @@ export class MessagesDbEffects implements OnInitEffects {
     () =>
       this.actions$.pipe(
         ofType(messagePagesActions.closePage),
-        switchMap(({ pageId }) => {
+        mergeMap(({ pageId }) => {
           return from(repository.closePage(pageId)).pipe(
             map(() => messagePagesEffectActions.pageClosed({ pageId })),
           );


### PR DESCRIPTION
## Summary
- Adds **Close tabs to the left**, **Close tabs to the right**, and **Close all tabs** to the tab right-click menu (closes #136). Items disable when there's nothing in that direction.
- Iterates closes from highest index down so the route reducer's position reindex doesn't create gaps.
- Fixes a latent bug: `closeMessagePage$` and `closePage$` used `switchMap`, which cancelled in-flight inner observables when multiple `closePage` actions were dispatched in rapid succession — leaving stale tabs in the UI until reload. Both now use `mergeMap`.

## Test plan
- [ ] Right-click a tab → menu shows Rename, Close, ---, Close tabs to the left, Close tabs to the right, Close all tabs
- [ ] First tab: "Close tabs to the left" is disabled
- [ ] Last tab: "Close tabs to the right" is disabled
- [ ] "Close all tabs" removes every tab in one click; remaining tabs do not linger after the action
- [ ] Reload the app afterwards — no orphaned pages reappear

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Messages can now be opened in popup windows for dedicated viewing
  * Added context menu with options to close tabs individually, to the left/right, or all at once

* **Refactoring**
  * Enhanced router configuration with improved component input binding support
  * Restructured application shell architecture for improved modularity and maintainability

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mligtenberg/ServicebusBrowser/pull/140?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->