### PR TITLE
docs(workspaces): glossary and ADRs for workspace feature

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,47 @@
+# Domain Glossary
+
+Canonical terms used in the Servicebus Browser codebase. Implementation details
+belong elsewhere (READMEs, ADRs, code). This file is a glossary only.
+
+## Workspace
+
+A named, user-selectable container that owns a set of **Connections** and a set
+of **Message Pages** (including each page's backing SQLite store, row
+selections, column ordering, and tab order). Exactly one Workspace is **active**
+at a time; switching workspaces swaps which connections and message pages are
+visible.
+
+A Workspace has a stable identity (UUID) separate from its display name. Names
+are freely renameable and are not required to be unique; identity never
+changes. Workspaces also carry a creation timestamp for informational purposes.
+
+- **Desktop:** Workspaces are created, renamed, and deleted through the UI.
+- **Web:** Workspaces are defined exclusively in the web config file; the UI
+  only switches between them.
+
+There is no privileged or sentinel "default" Workspace. The initial Workspace
+created during migration is named "Default" but can be renamed or deleted like
+any other. The application enforces that at least one Workspace exists at all
+times, and that the currently active Workspace cannot be deleted (the user must
+switch away first).
+
+Switching the active Workspace tears down all in-flight message receivers and
+loads belonging to the previous Workspace; if any load is in progress the user
+is asked to confirm.
+
+Out of scope for a Workspace: saved filters (no such feature), modification
+engine presets, exported action lists (live on disk outside the app), logs,
+**Topology** state (derived live from a Connection), **Tasks** (ephemeral job
+tracking), and global UI preferences.
+
+## Connection
+
+A configured Service Bus or Event Hub endpoint. Connections are owned by a
+single Workspace.
+
+## Message Page
+
+A tab in the message-viewing UI representing one retrieved set of messages from
+a queue/topic/subscription. Each Message Page has its own SQLite store
+(OPFS-backed), row selection state, and column ordering. Message Pages are
+owned by a single Workspace.

--- a/docs/adr/0001-single-active-workspace.md
+++ b/docs/adr/0001-single-active-workspace.md
@@ -1,0 +1,18 @@
+# Single active Workspace at a time
+
+A Workspace scopes the visible Connections and Message Pages. We chose to allow
+exactly one active Workspace per app session rather than letting pages from
+multiple Workspaces coexist in the tab bar.
+
+The alternative — concurrent multi-Workspace tabs — would make Workspaces a
+*filter* over a single global page set rather than a *context* the user
+inhabits. That breaks the mental model implied by the menu-bar switcher, makes
+connection operations ambiguous ("send to queue X" — which Workspace's X?), and
+forces every store and effect to thread workspace context into operations
+rather than reading the active Workspace at the boundary.
+
+Single-active keeps the existing `MessagesStore` / `ConnectionsStore` shapes
+intact: they always describe the active Workspace, and switching is implemented
+as a tear-down + rehydrate cycle rather than a pervasive scoping change. If
+real demand for cross-Workspace concurrent viewing emerges later, it can be
+added as a layered "compare" mode without inverting the foundation.

--- a/docs/adr/0002-workspace-persistence-foreign-key-namespacing.md
+++ b/docs/adr/0002-workspace-persistence-foreign-key-namespacing.md
@@ -1,0 +1,31 @@
+# Workspace persistence via foreign-key namespacing
+
+Workspace ownership of Connections and Message Pages is recorded by adding a
+`workspaceId` to existing records, not by partitioning storage into one
+file/database per Workspace. Concretely:
+
+- `sbb-connections.json` (desktop, encrypted) stays a single file; each
+  Connection gains a `workspaceId`.
+- `pages.sqlite3` (OPFS) stays a single database; the `pages` table gains a
+  `workspaceId` column.
+- `pagesOrder` in `localStorage` becomes `{ [workspaceId]: string[] }`.
+- A new `sbb-workspaces.json` (encrypted, versioned) holds the Workspace
+  registry and last-active id.
+- The per-page message SQLite files **are** physically partitioned by
+  Workspace: `sqlite/{workspaceId}/{pageId}.sqlite3` in OPFS. This is purely
+  operational — deleting a Workspace becomes "drop the directory" rather than
+  iterating page ids to unlink files. The directory name is the workspace UUID,
+  never the display name (names are renameable; identity is not).
+
+The rejected alternative was file-per-Workspace partitioning of *every* store
+(`sbb-connections-{wsId}.json`, `pages-{wsId}.sqlite3`). It would give "hard"
+isolation, but Workspaces are not a security boundary (same user, same
+machine), and the partitioned model makes future cross-Workspace operations
+(move/import/export) into multi-file dances instead of single-row updates. It
+also multiplies the number of files the encryption layer and migration logic
+must track.
+
+Connection and Page IDs remain **globally unique UUIDs**, not unique within a
+Workspace. This means a future "move connection between Workspaces" feature is
+a `WHERE id = ?` UPDATE rather than a re-key, and no per-page SQLite file can
+collide across Workspaces even if the subdirectory layout were ever flattened.

--- a/docs/adr/0003-hard-cancel-receivers-on-workspace-switch.md
+++ b/docs/adr/0003-hard-cancel-receivers-on-workspace-switch.md
@@ -1,0 +1,23 @@
+# Hard-cancel active receivers on Workspace switch
+
+When the user switches the active Workspace, all in-flight Service Bus / Event
+Hub receivers, peek loops, and continuation-token reads belonging to the
+previous Workspace are torn down. If anything is mid-load at the moment of
+switch, the user is shown an explicit confirmation first; cancelling the
+confirmation reverts the switcher to the previously active Workspace.
+
+The rejected alternative was to keep receivers running in the background so
+that a user could switch back later and find pages further along. That sounds
+user-friendly but has real costs in this domain: Service Bus receivers hold
+server-side state and message locks that expire on a timer, so a "backgrounded"
+receiver in an unwatched Workspace can silently let locks lapse and
+redeliver — surprising behaviour for a tool whose entire job is making message
+state legible. It also creates ambiguous resource accounting (how many live
+receivers does the app have? where?) and complicates the UI ("loading…" in a
+Workspace the user can't see).
+
+Hard-cancel keeps the invariant that the active Workspace is the **only**
+place with live brokers, which makes the rest of the system simpler: inactive
+Workspaces are pure persisted state, and the [continuation-token
+behavior](../messages-reader-continuation-token-behavior.md) already provides
+clean stopping points.

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,6 +11,12 @@ Welcome to the documentation for Servicebus Browser. This repository contains in
 - [Event Hub Namespace REST Authentication](./event-hub-namespace-rest-auth.md): SAS token generation and API versioning for Event Hub namespace management calls.
 - [Messages Reader Continuation Token Behavior](./messages-reader-continuation-token-behavior.md): Cross-broker continuation-token rules to stop message loading exactly at requested limits.
 
+## Architecture Decision Records
+
+- [ADR-0001: Single active Workspace at a time](./adr/0001-single-active-workspace.md)
+- [ADR-0002: Workspace persistence via foreign-key namespacing](./adr/0002-workspace-persistence-foreign-key-namespacing.md)
+- [ADR-0003: Hard-cancel active receivers on Workspace switch](./adr/0003-hard-cancel-receivers-on-workspace-switch.md)
+
 ## Project Structure
 
 - `apps/`: Main applications (Electron and Web).


### PR DESCRIPTION
## Summary

Documentation-only PR capturing the design decisions from a grilling session for the upcoming workspaces feature. No code changes — the implementation lands across a series of issues (#142–#146).

- **CONTEXT.md** — domain glossary defining Workspace, Connection, and Message Page.
- **docs/adr/0001-single-active-workspace.md** — exactly one Workspace is active at a time; switching is tear-down + rehydrate.
- **docs/adr/0002-workspace-persistence-foreign-key-namespacing.md** — `workspaceId` added to existing stores rather than partitioning into per-workspace files; per-page SQLite files move into `sqlite/{workspaceId}/{pageId}.sqlite3` under OPFS.
- **docs/adr/0003-hard-cancel-receivers-on-workspace-switch.md** — switching tears down all in-flight receivers (broker-lock implications make background continuation a footgun).
- **docs/index.md** — indexes the new ADR section.

## Test plan

- [ ] Documentation renders correctly on GitHub
- [ ] Links between CONTEXT.md, the ADRs, and docs/index.md all resolve

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added architecture decision records documenting workspace design (single active workspace per session), persistence strategy with foreign-key namespacing across connections and message pages, and receiver cancellation behavior during workspace transitions.
  * Added domain glossary defining key terminology for Workspace, Connection, and Message Page concepts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mligtenberg/ServicebusBrowser/pull/147?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->