### PR TITLE
feat(workspaces): workspace switcher UI + create flow (issue #143)

### DIFF
--- a/apps/servicebus-browser-app/src/app/events/secure-storage/workspace-storage.ts
+++ b/apps/servicebus-browser-app/src/app/events/secure-storage/workspace-storage.ts
@@ -1,4 +1,4 @@
-import { Workspace } from '@service-bus-browser/shared-contracts';
+import { UUID, Workspace } from '@service-bus-browser/shared-contracts';
 import { safeStorage } from 'electron';
 import path from 'path';
 import * as fs from 'fs';
@@ -6,6 +6,7 @@ import * as fs from 'fs';
 interface WorkspacesFile {
   version: 1;
   workspaces: Workspace[];
+  activeWorkspaceId?: UUID;
 }
 
 export class WorkspaceStorage {
@@ -34,5 +35,15 @@ export class WorkspaceStorage {
 
   listWorkspaces(): Workspace[] {
     return this.read()?.workspaces ?? [];
+  }
+
+  createWorkspace(workspace: Workspace): void {
+    const current = this.read() ?? { version: 1, workspaces: [] };
+    this.write({ ...current, workspaces: [...current.workspaces, workspace] });
+  }
+
+  setActiveWorkspaceId(id: UUID): void {
+    const current = this.read() ?? { version: 1, workspaces: [] };
+    this.write({ ...current, activeWorkspaceId: id });
   }
 }

--- a/apps/servicebus-browser-frontend/src/app/main-shell/main-shell.html
+++ b/apps/servicebus-browser-frontend/src/app/main-shell/main-shell.html
@@ -3,18 +3,9 @@
   [useLowProfileMenu]="isMac"
   [menuItems]="menuItems"
 >
-  @if (activeWorkspace(); as ws) {
-    <ng-template #menuStart>
-      <div
-        class="workspace-indicator"
-        [class.with-window-controls]="windowControlSpacing()"
-      >
-        <span
-          class="workspace-avatar"
-          [ngStyle]="{ 'background-color': workspaceAvatarColor() }"
-        >{{ workspaceInitial() }}</span>
-        <span class="workspace-name">{{ ws.name }}</span>
-      </div>
-    </ng-template>
-  }
+  <ng-template #menuStart>
+    <app-workspace-switcher
+      [class.with-window-controls]="windowControlSpacing()"
+    />
+  </ng-template>
 </lib-main-ui>

--- a/apps/servicebus-browser-frontend/src/app/main-shell/main-shell.scss
+++ b/apps/servicebus-browser-frontend/src/app/main-shell/main-shell.scss
@@ -70,42 +70,6 @@
   }
 }
 
-.workspace-indicator {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  padding: 0 10px 0 6px;
-  margin-right: 4px;
-  border-right: 1px solid var(--p-menubar-border-color, var(--p-content-border-color));
-  color: var(--p-menubar-item-color, var(--p-text-muted-color));
-  -webkit-app-region: none;
-
-  &.with-window-controls {
-    padding-left: 14px;
-    margin-left: 4px;
-  }
-}
-
-.workspace-avatar {
-  width: 18px;
-  height: 18px;
-  border-radius: 50%;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  font-size: 10px;
-  font-weight: 600;
-  color: white;
-  flex-shrink: 0;
-  opacity: 0.9;
-}
-
-.workspace-name {
-  font-size: inherit;
-  font-weight: 400;
-  white-space: nowrap;
-}
-
 .router-outlet {
   height: 100%;
   width: 100%;

--- a/apps/servicebus-browser-frontend/src/app/main-shell/main-shell.ts
+++ b/apps/servicebus-browser-frontend/src/app/main-shell/main-shell.ts
@@ -1,10 +1,10 @@
 import { Component, computed, effect, inject, signal } from '@angular/core';
 import { MainUiComponent } from '@service-bus-browser/main-ui';
-import { ColorThemeService, WorkspaceService } from '@service-bus-browser/services';
+import { ColorThemeService } from '@service-bus-browser/services';
 import { MenuItem } from 'primeng/api';
 import { messagesActions } from '@service-bus-browser/messages-store';
 import { Store } from '@ngrx/store';
-import { NgStyle } from '@angular/common';
+import { WorkspaceSwitcherComponent } from './workspace-switcher/workspace-switcher';
 
 interface ElectronWindow {
   electron?: {
@@ -14,21 +14,8 @@ interface ElectronWindow {
   };
 }
 
-const AVATAR_COLORS = [
-  '#5B9BD5', '#ED7D31', '#A9D18E', '#FF0000',
-  '#FFC000', '#00B0F0', '#7030A0', '#70AD47',
-];
-
-function workspaceAvatarColor(id: string): string {
-  let hash = 0;
-  for (let i = 0; i < id.length; i++) {
-    hash = (hash * 31 + id.charCodeAt(i)) >>> 0;
-  }
-  return AVATAR_COLORS[hash % AVATAR_COLORS.length];
-}
-
 @Component({
-  imports: [MainUiComponent, NgStyle],
+  imports: [MainUiComponent, WorkspaceSwitcherComponent],
   selector: 'app-main-shell',
   templateUrl: './main-shell.html',
   styleUrl: './main-shell.scss',
@@ -38,23 +25,12 @@ export class MainShell {
   isMac = this.electron?.platform === 'darwin';
 
   store = inject(Store);
-  workspaceService = inject(WorkspaceService);
 
   fullscreen = signal<boolean>(false);
   windowControlSpacing = computed(() => this.isMac && !this.fullscreen());
 
   themeService = inject(ColorThemeService);
   darkMode = this.themeService.darkMode;
-
-  activeWorkspace = this.workspaceService.activeWorkspace;
-  workspaceAvatarColor = computed(() => {
-    const ws = this.activeWorkspace();
-    return ws ? workspaceAvatarColor(ws.id) : '#888';
-  });
-  workspaceInitial = computed(() => {
-    const ws = this.activeWorkspace();
-    return ws ? ws.name.charAt(0).toUpperCase() : '?';
-  });
 
   menuItems: MenuItem[] = [
     {

--- a/apps/servicebus-browser-frontend/src/app/main-shell/workspace-switcher/workspace-switcher.html
+++ b/apps/servicebus-browser-frontend/src/app/main-shell/workspace-switcher/workspace-switcher.html
@@ -1,0 +1,84 @@
+<button
+  class="ws-trigger"
+  (click)="togglePopover($event)"
+  [class.with-window-controls]="false"
+  type="button"
+>
+  @if (activeWorkspace(); as ws) {
+    <span class="ws-avatar" [ngStyle]="{ 'background-color': activeColor() }">
+      {{ activeInitials() }}
+    </span>
+    <span class="ws-name">{{ ws.name }}</span>
+    <span class="pi pi-chevron-down ws-chevron"></span>
+  }
+</button>
+
+<p-popover #op styleClass="ws-popover">
+  <div class="ws-dropdown">
+    <button class="ws-new-action" (click)="openCreateDialog()" type="button">
+      <span class="pi pi-plus"></span>
+      New Workspace…
+    </button>
+
+    <div class="ws-separator"></div>
+
+    <div class="ws-section-label">Active</div>
+    @if (activeWorkspace(); as ws) {
+      <div class="ws-row ws-row--active">
+        <span class="ws-avatar ws-avatar--sm" [ngStyle]="{ 'background-color': avatarColor(ws) }">
+          {{ initials(ws) }}
+        </span>
+        <span class="ws-row-name">{{ ws.name }}</span>
+      </div>
+    }
+
+    @if (otherWorkspaces().length > 0) {
+      <div class="ws-separator"></div>
+      <div class="ws-section-label">Workspaces</div>
+      @for (ws of otherWorkspaces(); track ws.id) {
+        <div class="ws-row ws-row--inactive" title="Switching between workspaces coming soon">
+          <span class="ws-avatar ws-avatar--sm" [ngStyle]="{ 'background-color': avatarColor(ws) }">
+            {{ initials(ws) }}
+          </span>
+          <span class="ws-row-name">{{ ws.name }}</span>
+        </div>
+      }
+    }
+  </div>
+</p-popover>
+
+<p-dialog
+  header="New Workspace"
+  [visible]="showCreateDialog()"
+  (visibleChange)="showCreateDialog.set($event)"
+  [modal]="true"
+  [style]="{ width: '360px' }"
+  [draggable]="false"
+>
+  <div class="create-form">
+    <label for="wsName" class="create-label">Workspace name</label>
+    <input
+      id="wsName"
+      pInputText
+      type="text"
+      placeholder="e.g. Production"
+      [ngModel]="newWorkspaceName()"
+      (ngModelChange)="newWorkspaceName.set($event)"
+      (keyup.enter)="submitCreate()"
+      class="create-input"
+    />
+  </div>
+  <ng-template #footer>
+    <p-button
+      label="Cancel"
+      severity="secondary"
+      (click)="cancelCreate()"
+    />
+    <p-button
+      label="Create"
+      [disabled]="!newWorkspaceName().trim() || creating()"
+      [loading]="creating()"
+      (click)="submitCreate()"
+    />
+  </ng-template>
+</p-dialog>

--- a/apps/servicebus-browser-frontend/src/app/main-shell/workspace-switcher/workspace-switcher.scss
+++ b/apps/servicebus-browser-frontend/src/app/main-shell/workspace-switcher/workspace-switcher.scss
@@ -1,0 +1,139 @@
+:host.with-window-controls .ws-trigger {
+  padding-left: 80px;
+}
+
+.ws-trigger {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 0 8px 0 6px;
+  margin-right: 4px;
+  border: none;
+  border-right: 1px solid var(--p-menubar-border-color, var(--p-content-border-color));
+  background: transparent;
+  color: var(--p-menubar-item-color, var(--p-text-muted-color));
+  cursor: pointer;
+  height: 100%;
+  -webkit-app-region: none;
+
+  &:hover {
+    background: var(--p-menubar-item-focus-background, var(--p-content-hover-background));
+    color: var(--p-menubar-item-focus-color, var(--p-text-color));
+  }
+}
+
+.ws-avatar {
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 9px;
+  font-weight: 700;
+  color: white;
+  flex-shrink: 0;
+  opacity: 0.9;
+
+  &--sm {
+    width: 20px;
+    height: 20px;
+    font-size: 9px;
+  }
+}
+
+.ws-name {
+  font-size: inherit;
+  font-weight: 400;
+  white-space: nowrap;
+  max-width: 140px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.ws-chevron {
+  font-size: 10px;
+  opacity: 0.6;
+}
+
+.ws-dropdown {
+  min-width: 220px;
+  padding: 4px 0;
+}
+
+.ws-new-action {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding: 8px 12px;
+  border: none;
+  background: transparent;
+  color: var(--p-primary-color);
+  cursor: pointer;
+  font-size: 0.875rem;
+  text-align: left;
+
+  &:hover {
+    background: var(--p-content-hover-background);
+  }
+
+  .pi {
+    font-size: 0.8rem;
+  }
+}
+
+.ws-separator {
+  height: 1px;
+  background: var(--p-content-border-color);
+  margin: 4px 0;
+}
+
+.ws-section-label {
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--p-text-muted-color);
+  padding: 4px 12px 2px;
+  font-weight: 600;
+}
+
+.ws-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 12px;
+  font-size: 0.875rem;
+
+  &--active {
+    background: var(--p-highlight-background);
+    color: var(--p-highlight-color);
+    font-weight: 500;
+  }
+
+  &--inactive {
+    opacity: 0.6;
+    cursor: not-allowed;
+  }
+}
+
+.ws-row-name {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.create-form {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.create-label {
+  font-size: 0.875rem;
+  font-weight: 500;
+}
+
+.create-input {
+  width: 100%;
+}

--- a/apps/servicebus-browser-frontend/src/app/main-shell/workspace-switcher/workspace-switcher.scss
+++ b/apps/servicebus-browser-frontend/src/app/main-shell/workspace-switcher/workspace-switcher.scss
@@ -1,5 +1,6 @@
 :host.with-window-controls .ws-trigger {
-  padding-left: 80px;
+  margin-left: 1em;
+
 }
 
 .ws-trigger {
@@ -9,7 +10,6 @@
   padding: 0 8px 0 6px;
   margin-right: 4px;
   border: none;
-  border-right: 1px solid var(--p-menubar-border-color, var(--p-content-border-color));
   background: transparent;
   color: var(--p-menubar-item-color, var(--p-text-muted-color));
   cursor: pointer;

--- a/apps/servicebus-browser-frontend/src/app/main-shell/workspace-switcher/workspace-switcher.ts
+++ b/apps/servicebus-browser-frontend/src/app/main-shell/workspace-switcher/workspace-switcher.ts
@@ -1,0 +1,105 @@
+import {
+  Component,
+  computed,
+  inject,
+  signal,
+  ViewChild,
+} from '@angular/core';
+import { NgStyle } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { Popover } from 'primeng/popover';
+import { Dialog } from 'primeng/dialog';
+import { Button } from 'primeng/button';
+import { InputText } from 'primeng/inputtext';
+import { WorkspaceService } from '@service-bus-browser/services';
+import { WorkspaceSwitchService } from '../../workspace-switch.service';
+import { Workspace } from '@service-bus-browser/shared-contracts';
+
+function workspaceAvatarColor(id: string): string {
+  let hash = 0;
+  for (let i = 0; i < id.length; i++) {
+    hash = (hash * 31 + id.charCodeAt(i)) >>> 0;
+  }
+  const hue = hash % 360;
+  return `hsl(${hue}, 55%, 45%)`;
+}
+
+function workspaceInitials(name: string): string {
+  const words = name.trim().split(/\s+/);
+  if (words.length >= 2) {
+    return (words[0][0] + words[1][0]).toUpperCase();
+  }
+  return name.substring(0, 2).toUpperCase();
+}
+
+@Component({
+  selector: 'app-workspace-switcher',
+  standalone: true,
+  imports: [NgStyle, FormsModule, Popover, Dialog, Button, InputText],
+  templateUrl: './workspace-switcher.html',
+  styleUrl: './workspace-switcher.scss',
+})
+export class WorkspaceSwitcherComponent {
+  @ViewChild('op') popover!: Popover;
+
+  workspaceService = inject(WorkspaceService);
+  switchService = inject(WorkspaceSwitchService);
+
+  activeWorkspace = this.workspaceService.activeWorkspace;
+  availableWorkspaces = this.workspaceService.availableWorkspaces;
+
+  activeColor = computed(() => {
+    const ws = this.activeWorkspace();
+    return ws ? workspaceAvatarColor(ws.id) : '#888';
+  });
+
+  activeInitials = computed(() => {
+    const ws = this.activeWorkspace();
+    return ws ? workspaceInitials(ws.name) : '??';
+  });
+
+  otherWorkspaces = computed(() => {
+    const active = this.activeWorkspace();
+    return this.availableWorkspaces()
+      .filter((w) => w.id !== active?.id)
+      .sort((a, b) => a.name.localeCompare(b.name));
+  });
+
+  showCreateDialog = signal(false);
+  newWorkspaceName = signal('');
+  creating = signal(false);
+
+  avatarColor(ws: Workspace): string {
+    return workspaceAvatarColor(ws.id);
+  }
+
+  initials(ws: Workspace): string {
+    return workspaceInitials(ws.name);
+  }
+
+  togglePopover(event: Event): void {
+    this.popover.toggle(event);
+  }
+
+  openCreateDialog(): void {
+    this.popover.hide();
+    this.newWorkspaceName.set('');
+    this.showCreateDialog.set(true);
+  }
+
+  async submitCreate(): Promise<void> {
+    const name = this.newWorkspaceName().trim();
+    if (!name || this.creating()) return;
+    this.creating.set(true);
+    try {
+      await this.switchService.createAndSwitch(name);
+      this.showCreateDialog.set(false);
+    } finally {
+      this.creating.set(false);
+    }
+  }
+
+  cancelCreate(): void {
+    this.showCreateDialog.set(false);
+  }
+}

--- a/apps/servicebus-browser-frontend/src/app/workspace-switch.service.ts
+++ b/apps/servicebus-browser-frontend/src/app/workspace-switch.service.ts
@@ -1,0 +1,33 @@
+import { inject, Injectable } from '@angular/core';
+import { Store } from '@ngrx/store';
+import { Workspace } from '@service-bus-browser/shared-contracts';
+import { WorkspaceService } from '@service-bus-browser/services';
+import { messagePagesEffectActions } from '@service-bus-browser/messages-store';
+import { switchMessagesDbWorkspace } from '@service-bus-browser/messages-db';
+import { pagesActions } from '@service-bus-browser/main-ui';
+import { TopologyActions } from '@service-bus-browser/topology-store';
+
+/**
+ * Coordinates a full workspace switch: persists the active workspace,
+ * resets the messages-db cache, and tears down + rehydrates all NgRx stores.
+ * Used by both "create then switch" and explicit workspace selection flows.
+ */
+@Injectable({ providedIn: 'root' })
+export class WorkspaceSwitchService {
+  private readonly store = inject(Store);
+  private readonly workspaceService = inject(WorkspaceService);
+
+  async switchTo(workspace: Workspace): Promise<void> {
+    await this.workspaceService.setActive(workspace);
+    switchMessagesDbWorkspace(workspace.id);
+    this.store.dispatch(messagePagesEffectActions.workspaceSwitched());
+    this.store.dispatch(pagesActions.loadPageOrderFromStorage({ orderOverrides: {} }));
+    this.store.dispatch(TopologyActions.loadTopologyRootNodes());
+  }
+
+  async createAndSwitch(name: string): Promise<Workspace> {
+    const workspace = await this.workspaceService.createWorkspace(name);
+    await this.switchTo(workspace);
+    return workspace;
+  }
+}

--- a/libs/api-clients/angular-bindings/src/web-backend-api.ts
+++ b/libs/api-clients/angular-bindings/src/web-backend-api.ts
@@ -77,11 +77,17 @@ export class WebBackendApi implements BackendApi {
 
   async workspacesDoRequest(
     requestType: string,
-    _request: unknown,
+    request: unknown,
   ): Promise<unknown> {
     switch (requestType) {
       case 'listWorkspaces':
         return this.listWorkspaces();
+      case 'createWorkspace':
+        return this.createWorkspace((request as { name: string }).name);
+      case 'setActiveWorkspace':
+        // On web the active workspace is tracked via WorkspaceService/localStorage;
+        // no separate persistence step is needed here.
+        return;
       default:
         throw new Error(`Unknown workspaces request: ${requestType}`);
     }
@@ -107,6 +113,20 @@ export class WebBackendApi implements BackendApi {
       JSON.stringify(workspaces),
     );
     return workspaces;
+  }
+
+  private createWorkspace(name: string): Workspace {
+    const workspaces = this.listWorkspaces();
+    const workspace: Workspace = {
+      id: crypto.randomUUID() as UUID,
+      name,
+      createdAt: new Date().toISOString(),
+    };
+    localStorage.setItem(
+      WebBackendApi.WORKSPACES_STORAGE_KEY,
+      JSON.stringify([...workspaces, workspace]),
+    );
+    return workspace;
   }
 
   private async decodeResponse(response: Blob): Promise<any> {

--- a/libs/api-clients/angular-bindings/src/web-backend-api.ts
+++ b/libs/api-clients/angular-bindings/src/web-backend-api.ts
@@ -116,7 +116,17 @@ export class WebBackendApi implements BackendApi {
   }
 
   private createWorkspace(name: string): Workspace {
+    name = name.trim();
+    if (name === '') {
+      throw new Error('Workspace name cannot be empty');
+    }
     const workspaces = this.listWorkspaces();
+    const duplicate = workspaces.some(
+      (w) => w.name.toLowerCase() === name.toLowerCase(),
+    );
+    if (duplicate) {
+      throw new Error(`A workspace named "${name}" already exists`);
+    }
     const workspace: Workspace = {
       id: crypto.randomUUID() as UUID,
       name,

--- a/libs/api-clients/clients/src/lib/workspaces-frontend-client.ts
+++ b/libs/api-clients/clients/src/lib/workspaces-frontend-client.ts
@@ -1,4 +1,4 @@
-import { Workspace } from '@service-bus-browser/shared-contracts';
+import { UUID, Workspace } from '@service-bus-browser/shared-contracts';
 import { BackendApi } from './backend-api';
 
 export class WorkspacesFrontendClient {
@@ -9,5 +9,16 @@ export class WorkspacesFrontendClient {
       'listWorkspaces',
       {},
     )) as Workspace[];
+  }
+
+  async createWorkspace(name: string): Promise<Workspace> {
+    return (await this.backendApi.workspacesDoRequest(
+      'createWorkspace',
+      { name },
+    )) as Workspace;
+  }
+
+  async setActiveWorkspaceId(id: UUID): Promise<void> {
+    await this.backendApi.workspacesDoRequest('setActiveWorkspace', { id });
   }
 }

--- a/libs/backend/server/src/lib/workspaces/types.ts
+++ b/libs/backend/server/src/lib/workspaces/types.ts
@@ -1,7 +1,9 @@
-import { Workspace } from '@service-bus-browser/shared-contracts';
+import { UUID, Workspace } from '@service-bus-browser/shared-contracts';
 
 export interface WorkspaceStore {
   listWorkspaces(): Workspace[];
+  createWorkspace(workspace: Workspace): void;
+  setActiveWorkspaceId(id: UUID): void;
 }
 
 export type WorkspacesServerFunc = (

--- a/libs/backend/server/src/lib/workspaces/workspaces-actions.ts
+++ b/libs/backend/server/src/lib/workspaces/workspaces-actions.ts
@@ -1,9 +1,28 @@
+import { UUID, Workspace } from '@service-bus-browser/shared-contracts';
 import { WorkspacesServerFunc } from './types';
 
 const listWorkspaces: WorkspacesServerFunc = async (_body, store) => {
   return store.listWorkspaces();
 };
 
+const createWorkspace: WorkspacesServerFunc = async (body, store) => {
+  const { name } = body as { name: string };
+  const workspace: Workspace = {
+    id: crypto.randomUUID() as UUID,
+    name,
+    createdAt: new Date().toISOString(),
+  };
+  store.createWorkspace(workspace);
+  return workspace;
+};
+
+const setActiveWorkspace: WorkspacesServerFunc = async (body, store) => {
+  const { id } = body as { id: UUID };
+  store.setActiveWorkspaceId(id);
+};
+
 export default new Map<string, WorkspacesServerFunc>([
   ['listWorkspaces', listWorkspaces],
+  ['createWorkspace', createWorkspace],
+  ['setActiveWorkspace', setActiveWorkspace],
 ]);

--- a/libs/main-ui/src/index.ts
+++ b/libs/main-ui/src/index.ts
@@ -6,6 +6,7 @@ import { PageEffects } from './lib/ngrx/page.effects';
 
 export * from './lib/main-ui/main-ui';
 export * from './lib/about/about.component';
+export { pagesActions } from './lib/ngrx/route.actions';
 
 export function provideMainUi() {
   return [

--- a/libs/messages/messages-db/src/index.ts
+++ b/libs/messages/messages-db/src/index.ts
@@ -1,5 +1,6 @@
+import { UUID } from '@service-bus-browser/shared-contracts';
 import { MessagesRepository } from './lib/messages-repository';
-import { getPagesDb, initializeWorkspace, getActiveWorkspaceId, migrateOpfsFiles } from './lib/get-database';
+import { getPagesDb, initializeWorkspace, getActiveWorkspaceId, migrateOpfsFiles, switchDatabaseWorkspace } from './lib/get-database';
 
 export { initializeWorkspace, getActiveWorkspaceId, migrateOpfsFiles };
 
@@ -11,4 +12,14 @@ export async function getMessagesRepository() {
   }
 
   return await repositoryPromise;
+}
+
+/**
+ * Switches the active workspace for all database access. Resets the cached
+ * repository and PagesDatabase so subsequent calls open connections scoped
+ * to the new workspace.
+ */
+export function switchMessagesDbWorkspace(workspaceId: UUID): void {
+  switchDatabaseWorkspace(workspaceId);
+  repositoryPromise = undefined;
 }

--- a/libs/messages/messages-db/src/lib/get-database.ts
+++ b/libs/messages/messages-db/src/lib/get-database.ts
@@ -44,9 +44,10 @@ export function getActiveWorkspaceId(): UUID {
 let dbPromise: Promise<PagesDatabase> | undefined;
 
 export async function getPagesDb(): Promise<PagesDatabase> {
-  const workspaceId = await workspaceReadyPromise;
+  await workspaceReadyPromise;
 
   if (!dbPromise) {
+    const workspaceId = activeWorkspaceId!;
     const pagesDb = new SqlitePagesDatabase();
     dbPromise = pagesDb.initialize(workspaceId).then(() => pagesDb);
   }
@@ -57,7 +58,8 @@ export async function getPagesDb(): Promise<PagesDatabase> {
 const dbs: Record<string, MessagesDatabase> = {};
 
 export async function getMessagesDb(page: Page): Promise<MessagesDatabase> {
-  const workspaceId = await workspaceReadyPromise;
+  await workspaceReadyPromise;
+  const workspaceId = activeWorkspaceId!;
   const dbKey = `${workspaceId}/${page.id}`;
 
   if (dbKey in dbs) {

--- a/libs/messages/messages-db/src/lib/get-database.ts
+++ b/libs/messages/messages-db/src/lib/get-database.ts
@@ -22,6 +22,16 @@ export function initializeWorkspace(workspaceId: UUID): void {
   workspaceResolve(workspaceId);
 }
 
+/**
+ * Switches the active workspace for database access. Resets the cached
+ * PagesDatabase promise so the next call to getPagesDb() opens a fresh
+ * connection scoped to the new workspace.
+ */
+export function switchDatabaseWorkspace(workspaceId: UUID): void {
+  activeWorkspaceId = workspaceId;
+  dbPromise = undefined;
+}
+
 export function getActiveWorkspaceId(): UUID {
   if (!activeWorkspaceId) {
     throw new Error('Workspace not initialized. Call initializeWorkspace() before accessing databases.');

--- a/libs/messages/store/src/lib/messages-db.effects.ts
+++ b/libs/messages/store/src/lib/messages-db.effects.ts
@@ -68,4 +68,11 @@ export class MessagesDbEffects implements OnInitEffects {
       ),
     { dispatch: false },
   );
+
+  reloadAfterWorkspaceSwitch$ = createEffect(() =>
+    this.actions$.pipe(
+      ofType(messagePagesEffectActions.workspaceSwitched),
+      map(() => messagePagesEffectActions.loadPagesFromDb()),
+    ),
+  );
 }

--- a/libs/messages/store/src/lib/messages.effect-actions.ts
+++ b/libs/messages/store/src/lib/messages.effect-actions.ts
@@ -48,5 +48,6 @@ export const messagePagesEffectActions = createActionGroup({
     'page closed': props<{
       pageId: UUID;
     }>(),
+    'workspace switched': emptyProps(),
   },
 });

--- a/libs/messages/store/src/lib/messages.store.ts
+++ b/libs/messages/store/src/lib/messages.store.ts
@@ -122,6 +122,7 @@ export const messagesReducer = createReducer(
       };
     },
   ),
+  on(messagePagesEffectActions.workspaceSwitched, () => initialState),
 );
 
 export const feature = createFeature({

--- a/libs/shared/services/src/lib/workspace.service.ts
+++ b/libs/shared/services/src/lib/workspace.service.ts
@@ -1,20 +1,20 @@
-import { Injectable, signal } from '@angular/core';
+import { inject, Injectable, signal } from '@angular/core';
 import { UUID, Workspace } from '@service-bus-browser/shared-contracts';
+import { WorkspacesFrontendClient } from '@service-bus-browser/service-bus-frontend-clients';
 
 @Injectable({
   providedIn: 'root',
 })
 export class WorkspaceService {
-  /**
-   * localStorage key for the active workspace id. The active selection is UI
-   * state, so it's stored in localStorage on both desktop and web — the
-   * registry of available workspaces lives elsewhere (encrypted file on
-   * desktop, localStorage on web) but the *active* pointer is uniform.
-   */
   private static readonly ACTIVE_WORKSPACE_ID_KEY = 'sbb-active-workspace-id';
 
   private readonly _activeWorkspace = signal<Workspace | undefined>(undefined);
   readonly activeWorkspace = this._activeWorkspace.asReadonly();
+
+  private readonly _availableWorkspaces = signal<Workspace[]>([]);
+  readonly availableWorkspaces = this._availableWorkspaces.asReadonly();
+
+  private readonly workspacesClient = inject(WorkspacesFrontendClient);
 
   /**
    * Picks the active workspace from the available list. Reads the last-active
@@ -26,6 +26,8 @@ export class WorkspaceService {
     if (workspaces.length === 0) {
       throw new Error('Cannot initialize WorkspaceService with empty workspace list');
     }
+
+    this._availableWorkspaces.set(workspaces);
 
     const storedId = localStorage.getItem(
       WorkspaceService.ACTIVE_WORKSPACE_ID_KEY,
@@ -43,5 +45,23 @@ export class WorkspaceService {
 
     this._activeWorkspace.set(active);
     return active;
+  }
+
+  /** Update active workspace signals + persist. Called by the coordinator. */
+  async setActive(workspace: Workspace): Promise<void> {
+    this._activeWorkspace.set(workspace);
+    localStorage.setItem(WorkspaceService.ACTIVE_WORKSPACE_ID_KEY, workspace.id);
+    await this.workspacesClient.setActiveWorkspaceId(workspace.id);
+  }
+
+  /** Add a newly created workspace to the available list. */
+  addWorkspace(workspace: Workspace): void {
+    this._availableWorkspaces.update((ws) => [...ws, workspace]);
+  }
+
+  async createWorkspace(name: string): Promise<Workspace> {
+    const workspace = await this.workspacesClient.createWorkspace(name);
+    this.addWorkspace(workspace);
+    return workspace;
   }
 }


### PR DESCRIPTION
## Summary

- Replaces static workspace indicator with a clickable switcher trigger (avatar with HSL color derived from workspace id hash, 2-letter initials, name, chevron)
- Dropdown shows **+ New Workspace…** header action, active workspace (highlighted), and other workspaces listed alphabetically
- **+ New Workspace…** opens a dialog; empty name is blocked; on submit creates the workspace, persists it, and switches immediately
- After creation the new workspace is active and empty (zero connections, zero pages) — persisted across restarts via `activeWorkspaceId` in `sbb-workspaces.json`
- Switch operation (`WorkspaceSwitchService.switchTo`) is a single reusable path: tears down messages store + route pages + topology, resets messages-db cache, then rehydrates — ready for the explicit-switch follow-up slice

## What changed

| Area | Change |
|---|---|
| `WorkspaceStorage` | Added `activeWorkspaceId` to file format, `createWorkspace()`, `setActiveWorkspaceId()` |
| `WorkspaceStore` / server actions | Added `createWorkspace` + `setActiveWorkspace` server-side handlers |
| `WorkspacesFrontendClient` | Added `createWorkspace()` + `setActiveWorkspaceId()` |
| `WebBackendApi` | Handles both new ops against localStorage (web variant) |
| `messages-db` | `switchMessagesDbWorkspace()` resets cached DB/repository promises |
| NgRx messages store | `workspaceSwitched` action resets state; effect reloads pages from new workspace DB |
| `WorkspaceService` | `availableWorkspaces` signal, `setActive()`, `createWorkspace()` |
| `WorkspaceSwitchService` (app-level) | Coordinator: `switchTo()` + `createAndSwitch()` — reusable by next slice |
| `WorkspaceSwitcherComponent` | New component replacing static indicator |
| `main-shell` | Wired up switcher, removed old indicator |

## Test plan

- [ ] Menu bar shows avatar (stable color) + workspace name + chevron
- [ ] Clicking opens dropdown with New Workspace…, Active section, Workspaces section
- [ ] Submitting empty name is blocked
- [ ] Creating a workspace switches to it immediately; topology/pages/messages reset
- [ ] New workspace persists across app restart (`activeWorkspaceId` in sbb-workspaces.json)
- [ ] No regression on foundation behavior from #142

Closes #143

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added workspace switcher component to the application shell, enabling users to view and manage available workspaces.
  * Users can now create new workspaces via an integrated dialog interface.
  * Users can seamlessly switch between workspaces within the application.

* **Refactor**
  * Reorganized workspace management functionality from the main shell into a dedicated workspace switcher component.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mligtenberg/ServicebusBrowser/pull/150?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->