### PR TITLE
feat(workspaces): explicit workspace switching + bug fixes (issue #144)

### DIFF
--- a/apps/servicebus-browser-app/src/app/events/secure-storage/connection-storage.ts
+++ b/apps/servicebus-browser-app/src/app/events/secure-storage/connection-storage.ts
@@ -4,11 +4,15 @@ import { safeStorage } from 'electron';
 import path from 'path';
 import * as fs from 'fs';
 import { ConnectionStore } from '@service-bus-browser/service-bus-server';
+import { WorkspaceStorage } from './workspace-storage';
 
 export class SecureConnectionStorage implements ConnectionStore {
   connectionsPath: string;
 
-  constructor(userDataMainFolder: string) {
+  constructor(
+    userDataMainFolder: string,
+    private readonly workspaceStorage?: WorkspaceStorage,
+  ) {
     this.connectionsPath = path.join(
       userDataMainFolder,
       'sbb-connections.json',
@@ -16,8 +20,11 @@ export class SecureConnectionStorage implements ConnectionStore {
   }
 
   addConnection(connection: Connection): void {
+    const activeWorkspaceId = this.workspaceStorage?.getActiveWorkspaceId();
     const connections = this.readCurrentConnections();
-    connections[connection.id] = connection;
+    connections[connection.id] = activeWorkspaceId
+      ? { ...connection, workspaceId: activeWorkspaceId }
+      : connection;
     this.writeConnections(connections);
   }
 
@@ -29,10 +36,17 @@ export class SecureConnectionStorage implements ConnectionStore {
 
   listConnections(): Array<{ connectionId: UUID; connectionName: string }> {
     const connections = this.readCurrentConnections();
-    return Object.entries(connections).map(([connectionId, connection]) => ({
-      connectionId: connectionId as UUID,
-      connectionName: connection.name,
-    }));
+    const activeWorkspaceId = this.workspaceStorage?.getActiveWorkspaceId();
+    return Object.entries(connections)
+      .filter(([_, connection]) =>
+        !activeWorkspaceId ||
+        !connection.workspaceId ||
+        connection.workspaceId === activeWorkspaceId,
+      )
+      .map(([connectionId, connection]) => ({
+        connectionId: connectionId as UUID,
+        connectionName: connection.name,
+      }));
   }
 
   getConnection(connectionId: UUID): Connection | undefined {

--- a/apps/servicebus-browser-app/src/app/events/secure-storage/workspace-storage.ts
+++ b/apps/servicebus-browser-app/src/app/events/secure-storage/workspace-storage.ts
@@ -46,4 +46,8 @@ export class WorkspaceStorage {
     const current = this.read() ?? { version: 1, workspaces: [] };
     this.write({ ...current, activeWorkspaceId: id });
   }
+
+  getActiveWorkspaceId(): UUID | undefined {
+    return this.read()?.activeWorkspaceId;
+  }
 }

--- a/apps/servicebus-browser-app/src/app/events/service-bus.events.ts
+++ b/apps/servicebus-browser-app/src/app/events/service-bus.events.ts
@@ -1,12 +1,15 @@
 import { ipcMain } from 'electron';
 import { Server } from '@service-bus-browser/service-bus-server';
 import { SecureConnectionStorage } from './secure-storage/connection-storage';
+import { WorkspaceStorage } from './secure-storage/workspace-storage';
 import App from '../app';
 
 let server: Server | undefined = undefined;
 export default class ServiceBusEvents {
   static bootstrapServiceBusEvents(): Electron.IpcMain {
-    server = new Server(new SecureConnectionStorage(App.application.getPath('userData')));
+    const userDataPath = App.application.getPath('userData');
+    const workspaceStorage = new WorkspaceStorage(userDataPath);
+    server = new Server(new SecureConnectionStorage(userDataPath, workspaceStorage));
     return ipcMain;
   }
 }

--- a/apps/servicebus-browser-frontend/src/app/main-shell/workspace-switcher/workspace-switcher.html
+++ b/apps/servicebus-browser-frontend/src/app/main-shell/workspace-switcher/workspace-switcher.html
@@ -36,12 +36,12 @@
       <div class="ws-separator"></div>
       <div class="ws-section-label">Workspaces</div>
       @for (ws of otherWorkspaces(); track ws.id) {
-        <div class="ws-row ws-row--inactive" title="Switching between workspaces coming soon">
+        <button class="ws-row ws-row--clickable" type="button" (click)="selectWorkspace(ws)">
           <span class="ws-avatar ws-avatar--sm" [ngStyle]="{ 'background-color': avatarColor(ws) }">
             {{ initials(ws) }}
           </span>
           <span class="ws-row-name">{{ ws.name }}</span>
-        </div>
+        </button>
       }
     }
   </div>
@@ -79,6 +79,32 @@
       [disabled]="!newWorkspaceName().trim() || creating()"
       [loading]="creating()"
       (click)="submitCreate()"
+    />
+  </ng-template>
+</p-dialog>
+
+<p-dialog
+  header="Switch Workspace"
+  [visible]="showConfirmDialog()"
+  (visibleChange)="!$event && cancelSwitch()"
+  [modal]="true"
+  [style]="{ width: '420px' }"
+  [draggable]="false"
+>
+  <p class="confirm-text">
+    One or more message loads are currently in progress. Switching workspaces
+    will cancel all active loads. Do you want to continue?
+  </p>
+  <ng-template #footer>
+    <p-button
+      label="Cancel"
+      severity="secondary"
+      (click)="cancelSwitch()"
+    />
+    <p-button
+      label="Continue"
+      severity="danger"
+      (click)="confirmSwitch()"
     />
   </ng-template>
 </p-dialog>

--- a/apps/servicebus-browser-frontend/src/app/main-shell/workspace-switcher/workspace-switcher.scss
+++ b/apps/servicebus-browser-frontend/src/app/main-shell/workspace-switcher/workspace-switcher.scss
@@ -111,9 +111,17 @@
     font-weight: 500;
   }
 
-  &--inactive {
-    opacity: 0.6;
-    cursor: not-allowed;
+  &--clickable {
+    width: 100%;
+    border: none;
+    background: transparent;
+    color: inherit;
+    cursor: pointer;
+    text-align: left;
+
+    &:hover {
+      background: var(--p-content-hover-background);
+    }
   }
 }
 
@@ -136,4 +144,11 @@
 
 .create-input {
   width: 100%;
+}
+
+.confirm-text {
+  margin: 0;
+  font-size: 0.875rem;
+  line-height: 1.5;
+  color: var(--p-text-color);
 }

--- a/apps/servicebus-browser-frontend/src/app/main-shell/workspace-switcher/workspace-switcher.ts
+++ b/apps/servicebus-browser-frontend/src/app/main-shell/workspace-switcher/workspace-switcher.ts
@@ -14,6 +14,8 @@ import { InputText } from 'primeng/inputtext';
 import { WorkspaceService } from '@service-bus-browser/services';
 import { WorkspaceSwitchService } from '../../workspace-switch.service';
 import { Workspace } from '@service-bus-browser/shared-contracts';
+import { Store } from '@ngrx/store';
+import { TasksSelectors } from '@service-bus-browser/tasks-store';
 
 function workspaceAvatarColor(id: string): string {
   let hash = 0;
@@ -42,11 +44,15 @@ function workspaceInitials(name: string): string {
 export class WorkspaceSwitcherComponent {
   @ViewChild('op') popover!: Popover;
 
+  private readonly store = inject(Store);
   workspaceService = inject(WorkspaceService);
   switchService = inject(WorkspaceSwitchService);
 
   activeWorkspace = this.workspaceService.activeWorkspace;
   availableWorkspaces = this.workspaceService.availableWorkspaces;
+
+  activeTasks = this.store.selectSignal(TasksSelectors.selectTasks);
+  hasActiveTasks = computed(() => this.activeTasks().length > 0);
 
   activeColor = computed(() => {
     const ws = this.activeWorkspace();
@@ -68,6 +74,9 @@ export class WorkspaceSwitcherComponent {
   showCreateDialog = signal(false);
   newWorkspaceName = signal('');
   creating = signal(false);
+
+  showConfirmDialog = signal(false);
+  pendingWorkspace = signal<Workspace | null>(null);
 
   avatarColor(ws: Workspace): string {
     return workspaceAvatarColor(ws.id);
@@ -101,5 +110,28 @@ export class WorkspaceSwitcherComponent {
 
   cancelCreate(): void {
     this.showCreateDialog.set(false);
+  }
+
+  selectWorkspace(ws: Workspace): void {
+    this.popover.hide();
+    if (this.hasActiveTasks()) {
+      this.pendingWorkspace.set(ws);
+      this.showConfirmDialog.set(true);
+    } else {
+      this.switchService.switchTo(ws);
+    }
+  }
+
+  async confirmSwitch(): Promise<void> {
+    const ws = this.pendingWorkspace();
+    if (!ws) return;
+    this.showConfirmDialog.set(false);
+    this.pendingWorkspace.set(null);
+    await this.switchService.switchTo(ws);
+  }
+
+  cancelSwitch(): void {
+    this.showConfirmDialog.set(false);
+    this.pendingWorkspace.set(null);
   }
 }

--- a/apps/servicebus-browser-frontend/src/app/workspace-switch.service.ts
+++ b/apps/servicebus-browser-frontend/src/app/workspace-switch.service.ts
@@ -6,6 +6,7 @@ import { messagePagesEffectActions } from '@service-bus-browser/messages-store';
 import { switchMessagesDbWorkspace } from '@service-bus-browser/messages-db';
 import { pagesActions } from '@service-bus-browser/main-ui';
 import { TopologyActions } from '@service-bus-browser/topology-store';
+import { TasksActions } from '@service-bus-browser/tasks-store';
 
 /**
  * Coordinates a full workspace switch: persists the active workspace,
@@ -18,6 +19,7 @@ export class WorkspaceSwitchService {
   private readonly workspaceService = inject(WorkspaceService);
 
   async switchTo(workspace: Workspace): Promise<void> {
+    this.store.dispatch(TasksActions.cancelAllTasks());
     await this.workspaceService.setActive(workspace);
     switchMessagesDbWorkspace(workspace.id);
     this.store.dispatch(messagePagesEffectActions.workspaceSwitched());

--- a/libs/tasks/store/src/lib/tasks.actions.ts
+++ b/libs/tasks/store/src/lib/tasks.actions.ts
@@ -28,3 +28,5 @@ export const completeTask = createAction(
     statusDescription?: string,
   }>()
 )
+
+export const cancelAllTasks = createAction('[Tasks] Cancel All Tasks')

--- a/libs/tasks/store/src/lib/tasks.store.ts
+++ b/libs/tasks/store/src/lib/tasks.store.ts
@@ -58,7 +58,8 @@ export const reducer = createReducer(
 on(Actions.completeTask, (state, { id }) => ({
     ...state,
     tasks: state.tasks.filter((task) => task.id !== id),
-  }))
+  })),
+  on(Actions.cancelAllTasks, () => initialState)
 );
 
 export const feature = createFeature({


### PR DESCRIPTION
## Summary

- **Workspace switching enabled** — non-active workspace rows in the switcher dropdown are now clickable buttons that invoke the existing `WorkspaceSwitchService.switchTo()` tear-down/rehydrate path
- **In-flight confirmation modal** — if tasks are running when the user picks a different workspace, a modal warns that loading will be cancelled; Cancel reverts the selection, Continue proceeds with the switch
- **Tasks actually cancelled on switch** — added `cancelAllTasks` action to the tasks store and dispatched it as the first step of `switchTo()`, so all in-flight `loadMessages`/`clearMessages` loops bail out on their next `isTaskCanceled` check
- **Connections filtered by workspace** — `SecureConnectionStorage.listConnections()` now reads the active workspace ID from `WorkspaceStorage` and filters connections accordingly; `addConnection()` stamps the active `workspaceId` on new connections

## What changed and why

### `workspace-switcher` (UI)
The inactive workspace rows were placeholder `<div>`s with `cursor: not-allowed` and a "coming soon" tooltip. They are now `<button>` elements with a `(click)="selectWorkspace(ws)"` handler. `selectWorkspace()` checks `hasActiveTasks` (a signal over `TasksSelectors.selectTasks`) — if tasks are running it opens a confirm dialog with a `pendingWorkspace` signal; otherwise it calls `switchService.switchTo()` directly. The SCSS `--inactive` modifier is replaced with `--clickable`.

### `WorkspaceSwitchService`
Added `TasksActions.cancelAllTasks()` as the very first dispatch in `switchTo()`. This clears the tasks store, which causes any running loop polling `isTaskCanceled()` to see itself as cancelled on its next iteration.

### Tasks store
New `cancelAllTasks` action that resets the store to `initialState` (empty tasks array).

### `SecureConnectionStorage` + `WorkspaceStorage` (Electron backend)
`WorkspaceStorage` exposes a new `getActiveWorkspaceId()` method. `SecureConnectionStorage` now accepts an optional `WorkspaceStorage` reference; `listConnections()` filters out connections whose `workspaceId` doesn't match the active workspace, and `addConnection()` stamps the active `workspaceId` onto new connections. `service-bus.events.ts` passes a `WorkspaceStorage` instance at construction time.

## Reviewer notes

- The connections filter is `!activeWorkspaceId || !connection.workspaceId || connection.workspaceId === activeWorkspaceId` — connections without a `workspaceId` are shown in all workspaces as a safe legacy fallback (the startup migration already stamps them, but the guard is defensive)
- The confirm dialog fires on **any** running task, including non-cancelable batch-resend tasks. This is intentional per ADR-0003 — the user still needs to be warned even if those tasks can't be soft-cancelled
- No regression: the create-and-switch flow from issue #143 goes through the same `switchTo()` path and picks up all three fixes automatically

Closes #144