### PR TITLE
feat(workspaces): rename + delete workspace with full cascade cleanup (issue #145)

### DIFF
--- a/apps/servicebus-browser-app/src/app/events/secure-storage/workspace-storage.ts
+++ b/apps/servicebus-browser-app/src/app/events/secure-storage/workspace-storage.ts
@@ -11,9 +11,11 @@ interface WorkspacesFile {
 
 export class WorkspaceStorage {
   private readonly workspacesPath: string;
+  private readonly connectionsPath: string;
 
   constructor(userDataMainFolder: string) {
     this.workspacesPath = path.join(userDataMainFolder, 'sbb-workspaces.json');
+    this.connectionsPath = path.join(userDataMainFolder, 'sbb-connections.json');
   }
 
   exists(): boolean {
@@ -49,5 +51,50 @@ export class WorkspaceStorage {
 
   getActiveWorkspaceId(): UUID | undefined {
     return this.read()?.activeWorkspaceId;
+  }
+
+  renameWorkspace(id: UUID, name: string): void {
+    const current = this.read() ?? { version: 1, workspaces: [] };
+    const workspaces = current.workspaces.map((w) =>
+      w.id === id ? { ...w, name } : w,
+    );
+    this.write({ ...current, workspaces });
+  }
+
+  deleteWorkspace(id: UUID): void {
+    const current = this.read() ?? { version: 1, workspaces: [] };
+    const workspaces = current.workspaces.filter((w) => w.id !== id);
+    const activeWorkspaceId =
+      current.activeWorkspaceId === id ? workspaces[0]?.id : current.activeWorkspaceId;
+    this.write({ ...current, workspaces, activeWorkspaceId });
+  }
+
+  countConnectionsByWorkspace(id: UUID): number {
+    const connections = this.readConnections();
+    return Object.values(connections).filter(
+      (c) => (c as any).workspaceId === id,
+    ).length;
+  }
+
+  deleteConnectionsByWorkspace(id: UUID): void {
+    const connections = this.readConnections();
+    const filtered = Object.fromEntries(
+      Object.entries(connections).filter(([, c]) => (c as any).workspaceId !== id),
+    );
+    this.writeConnections(filtered);
+  }
+
+  private readConnections(): Record<string, unknown> {
+    if (!fs.existsSync(this.connectionsPath)) return {};
+    const buffer = fs.readFileSync(this.connectionsPath);
+    const json = safeStorage.decryptString(buffer);
+    return JSON.parse(json);
+  }
+
+  private writeConnections(connections: Record<string, unknown>): void {
+    if (!fs.existsSync(this.connectionsPath)) return;
+    const json = JSON.stringify(connections);
+    const encrypted = safeStorage.encryptString(json);
+    fs.writeFileSync(this.connectionsPath, encrypted, { encoding: 'utf8' });
   }
 }

--- a/apps/servicebus-browser-frontend/src/app/main-shell/workspace-switcher/workspace-switcher.html
+++ b/apps/servicebus-browser-frontend/src/app/main-shell/workspace-switcher/workspace-switcher.html
@@ -29,6 +29,15 @@
           {{ initials(ws) }}
         </span>
         <span class="ws-row-name">{{ ws.name }}</span>
+        <button
+          class="ws-action-btn"
+          type="button"
+          pTooltip="Rename workspace"
+          tooltipPosition="top"
+          (click)="openRenameDialog()"
+        >
+          <span class="pi pi-pencil"></span>
+        </button>
       </div>
     }
 
@@ -41,6 +50,15 @@
             {{ initials(ws) }}
           </span>
           <span class="ws-row-name">{{ ws.name }}</span>
+          <button
+            class="ws-action-btn ws-action-btn--danger"
+            type="button"
+            pTooltip="Delete workspace"
+            tooltipPosition="top"
+            (click)="$event.stopPropagation(); openDeleteDialog(ws)"
+          >
+            <span class="pi pi-trash"></span>
+          </button>
         </button>
       }
     }
@@ -84,6 +102,41 @@
 </p-dialog>
 
 <p-dialog
+  header="Rename Workspace"
+  [visible]="showRenameDialog()"
+  (visibleChange)="!$event && cancelRename()"
+  [modal]="true"
+  [style]="{ width: '360px' }"
+  [draggable]="false"
+>
+  <div class="create-form">
+    <label for="wsRenameName" class="create-label">Workspace name</label>
+    <input
+      id="wsRenameName"
+      pInputText
+      type="text"
+      [ngModel]="renameWorkspaceName()"
+      (ngModelChange)="renameWorkspaceName.set($event)"
+      (keyup.enter)="submitRename()"
+      class="create-input"
+    />
+  </div>
+  <ng-template #footer>
+    <p-button
+      label="Cancel"
+      severity="secondary"
+      (click)="cancelRename()"
+    />
+    <p-button
+      label="Rename"
+      [disabled]="!renameWorkspaceName().trim() || renaming()"
+      [loading]="renaming()"
+      (click)="submitRename()"
+    />
+  </ng-template>
+</p-dialog>
+
+<p-dialog
   header="Switch Workspace"
   [visible]="showConfirmDialog()"
   (visibleChange)="!$event && cancelSwitch()"
@@ -105,6 +158,41 @@
       label="Continue"
       severity="danger"
       (click)="confirmSwitch()"
+    />
+  </ng-template>
+</p-dialog>
+
+<p-dialog
+  [header]="'Delete ' + (deleteTarget()?.name ?? 'Workspace')"
+  [visible]="showDeleteDialog()"
+  (visibleChange)="!$event && cancelDelete()"
+  [modal]="true"
+  [style]="{ width: '440px' }"
+  [draggable]="false"
+>
+  @if (deleteStats(); as stats) {
+    <p class="confirm-text">
+      This will permanently destroy
+      <strong>{{ stats.connectionCount }} connection{{ stats.connectionCount !== 1 ? 's' : '' }}</strong>,
+      <strong>{{ stats.pageCount }} message page{{ stats.pageCount !== 1 ? 's' : '' }}</strong>,
+      and all stored messages for this workspace.
+      <strong>This cannot be undone.</strong>
+    </p>
+  } @else {
+    <p class="confirm-text">Loading workspace details…</p>
+  }
+  <ng-template #footer>
+    <p-button
+      label="Cancel"
+      severity="secondary"
+      (click)="cancelDelete()"
+    />
+    <p-button
+      label="Delete"
+      severity="danger"
+      [disabled]="!deleteStats() || deleting()"
+      [loading]="deleting()"
+      (click)="confirmDelete()"
     />
   </ng-template>
 </p-dialog>

--- a/apps/servicebus-browser-frontend/src/app/main-shell/workspace-switcher/workspace-switcher.scss
+++ b/apps/servicebus-browser-frontend/src/app/main-shell/workspace-switcher/workspace-switcher.scss
@@ -126,9 +126,46 @@
 }
 
 .ws-row-name {
+  flex: 1;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+}
+
+.ws-action-btn {
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  border: none;
+  border-radius: 4px;
+  background: transparent;
+  color: var(--p-text-muted-color);
+  cursor: pointer;
+  padding: 0;
+  opacity: 0;
+  transition: opacity 0.15s, background 0.15s, color 0.15s;
+
+  .pi {
+    font-size: 0.75rem;
+  }
+
+  &:hover {
+    background: var(--p-content-hover-background);
+    color: var(--p-text-color);
+  }
+
+  &--danger:hover {
+    background: var(--p-red-100, rgba(239, 68, 68, 0.1));
+    color: var(--p-red-500, #ef4444);
+  }
+}
+
+.ws-row:hover .ws-action-btn,
+.ws-row--active .ws-action-btn {
+  opacity: 1;
 }
 
 .create-form {

--- a/apps/servicebus-browser-frontend/src/app/main-shell/workspace-switcher/workspace-switcher.ts
+++ b/apps/servicebus-browser-frontend/src/app/main-shell/workspace-switcher/workspace-switcher.ts
@@ -11,11 +11,13 @@ import { Popover } from 'primeng/popover';
 import { Dialog } from 'primeng/dialog';
 import { Button } from 'primeng/button';
 import { InputText } from 'primeng/inputtext';
+import { Tooltip } from 'primeng/tooltip';
 import { WorkspaceService } from '@service-bus-browser/services';
 import { WorkspaceSwitchService } from '../../workspace-switch.service';
 import { Workspace } from '@service-bus-browser/shared-contracts';
 import { Store } from '@ngrx/store';
 import { TasksSelectors } from '@service-bus-browser/tasks-store';
+import { countPagesByWorkspace, deleteWorkspaceData } from '@service-bus-browser/messages-db';
 
 function workspaceAvatarColor(id: string): string {
   let hash = 0;
@@ -37,7 +39,7 @@ function workspaceInitials(name: string): string {
 @Component({
   selector: 'app-workspace-switcher',
   standalone: true,
-  imports: [NgStyle, FormsModule, Popover, Dialog, Button, InputText],
+  imports: [NgStyle, FormsModule, Popover, Dialog, Button, InputText, Tooltip],
   templateUrl: './workspace-switcher.html',
   styleUrl: './workspace-switcher.scss',
 })
@@ -77,6 +79,16 @@ export class WorkspaceSwitcherComponent {
 
   showConfirmDialog = signal(false);
   pendingWorkspace = signal<Workspace | null>(null);
+
+  showRenameDialog = signal(false);
+  renameTarget = signal<Workspace | null>(null);
+  renameWorkspaceName = signal('');
+  renaming = signal(false);
+
+  showDeleteDialog = signal(false);
+  deleteTarget = signal<Workspace | null>(null);
+  deleteStats = signal<{ connectionCount: number; pageCount: number } | null>(null);
+  deleting = signal(false);
 
   avatarColor(ws: Workspace): string {
     return workspaceAvatarColor(ws.id);
@@ -133,5 +145,64 @@ export class WorkspaceSwitcherComponent {
   cancelSwitch(): void {
     this.showConfirmDialog.set(false);
     this.pendingWorkspace.set(null);
+  }
+
+  openRenameDialog(): void {
+    const ws = this.activeWorkspace();
+    if (!ws) return;
+    this.popover.hide();
+    this.renameTarget.set(ws);
+    this.renameWorkspaceName.set(ws.name);
+    this.showRenameDialog.set(true);
+  }
+
+  async submitRename(): Promise<void> {
+    const ws = this.renameTarget();
+    const name = this.renameWorkspaceName().trim();
+    if (!ws || !name || this.renaming()) return;
+    this.renaming.set(true);
+    try {
+      await this.workspaceService.renameWorkspace(ws.id, name);
+      this.showRenameDialog.set(false);
+    } finally {
+      this.renaming.set(false);
+    }
+  }
+
+  cancelRename(): void {
+    this.showRenameDialog.set(false);
+    this.renameTarget.set(null);
+  }
+
+  async openDeleteDialog(ws: Workspace): Promise<void> {
+    this.popover.hide();
+    this.deleteTarget.set(ws);
+    this.deleteStats.set(null);
+    this.showDeleteDialog.set(true);
+    const [connectionCount, pageCount] = await Promise.all([
+      this.workspaceService.countConnectionsByWorkspace(ws.id),
+      countPagesByWorkspace(ws.id),
+    ]);
+    this.deleteStats.set({ connectionCount, pageCount });
+  }
+
+  async confirmDelete(): Promise<void> {
+    const ws = this.deleteTarget();
+    if (!ws || this.deleting()) return;
+    this.deleting.set(true);
+    try {
+      await this.workspaceService.deleteWorkspace(ws.id);
+      await deleteWorkspaceData(ws.id);
+      this.showDeleteDialog.set(false);
+      this.deleteTarget.set(null);
+    } finally {
+      this.deleting.set(false);
+    }
+  }
+
+  cancelDelete(): void {
+    this.showDeleteDialog.set(false);
+    this.deleteTarget.set(null);
+    this.deleteStats.set(null);
   }
 }

--- a/libs/api-clients/angular-bindings/src/web-backend-api.ts
+++ b/libs/api-clients/angular-bindings/src/web-backend-api.ts
@@ -88,6 +88,16 @@ export class WebBackendApi implements BackendApi {
         // On web the active workspace is tracked via WorkspaceService/localStorage;
         // no separate persistence step is needed here.
         return;
+      case 'renameWorkspace':
+        return this.renameWorkspace(
+          (request as { id: UUID; name: string }).id,
+          (request as { id: UUID; name: string }).name,
+        );
+      case 'deleteWorkspace':
+        return this.deleteWorkspaceFromStorage((request as { id: UUID }).id);
+      case 'countConnectionsByWorkspace':
+        // Web has no server-side connection tracking per workspace.
+        return 0;
       default:
         throw new Error(`Unknown workspaces request: ${requestType}`);
     }
@@ -113,6 +123,26 @@ export class WebBackendApi implements BackendApi {
       JSON.stringify(workspaces),
     );
     return workspaces;
+  }
+
+  private renameWorkspace(id: UUID, name: string): void {
+    name = name.trim();
+    if (name === '') throw new Error('Workspace name cannot be empty');
+    const workspaces = this.listWorkspaces().map((w) =>
+      w.id === id ? { ...w, name } : w,
+    );
+    localStorage.setItem(
+      WebBackendApi.WORKSPACES_STORAGE_KEY,
+      JSON.stringify(workspaces),
+    );
+  }
+
+  private deleteWorkspaceFromStorage(id: UUID): void {
+    const workspaces = this.listWorkspaces().filter((w) => w.id !== id);
+    localStorage.setItem(
+      WebBackendApi.WORKSPACES_STORAGE_KEY,
+      JSON.stringify(workspaces),
+    );
   }
 
   private createWorkspace(name: string): Workspace {

--- a/libs/api-clients/clients/src/lib/workspaces-frontend-client.ts
+++ b/libs/api-clients/clients/src/lib/workspaces-frontend-client.ts
@@ -21,4 +21,19 @@ export class WorkspacesFrontendClient {
   async setActiveWorkspaceId(id: UUID): Promise<void> {
     await this.backendApi.workspacesDoRequest('setActiveWorkspace', { id });
   }
+
+  async renameWorkspace(id: UUID, name: string): Promise<void> {
+    await this.backendApi.workspacesDoRequest('renameWorkspace', { id, name });
+  }
+
+  async deleteWorkspace(id: UUID): Promise<void> {
+    await this.backendApi.workspacesDoRequest('deleteWorkspace', { id });
+  }
+
+  async countConnectionsByWorkspace(id: UUID): Promise<number> {
+    return (await this.backendApi.workspacesDoRequest(
+      'countConnectionsByWorkspace',
+      { id },
+    )) as number;
+  }
 }

--- a/libs/backend/server/src/lib/workspaces/types.ts
+++ b/libs/backend/server/src/lib/workspaces/types.ts
@@ -4,6 +4,10 @@ export interface WorkspaceStore {
   listWorkspaces(): Workspace[];
   createWorkspace(workspace: Workspace): void;
   setActiveWorkspaceId(id: UUID): void;
+  renameWorkspace(id: UUID, name: string): void;
+  deleteWorkspace(id: UUID): void;
+  countConnectionsByWorkspace(id: UUID): number;
+  deleteConnectionsByWorkspace(id: UUID): void;
 }
 
 export type WorkspacesServerFunc = (

--- a/libs/backend/server/src/lib/workspaces/workspaces-actions.ts
+++ b/libs/backend/server/src/lib/workspaces/workspaces-actions.ts
@@ -21,8 +21,27 @@ const setActiveWorkspace: WorkspacesServerFunc = async (body, store) => {
   store.setActiveWorkspaceId(id);
 };
 
+const renameWorkspace: WorkspacesServerFunc = async (body, store) => {
+  const { id, name } = body as { id: UUID; name: string };
+  store.renameWorkspace(id, name);
+};
+
+const deleteWorkspace: WorkspacesServerFunc = async (body, store) => {
+  const { id } = body as { id: UUID };
+  store.deleteConnectionsByWorkspace(id);
+  store.deleteWorkspace(id);
+};
+
+const countConnectionsByWorkspace: WorkspacesServerFunc = async (body, store) => {
+  const { id } = body as { id: UUID };
+  return store.countConnectionsByWorkspace(id);
+};
+
 export default new Map<string, WorkspacesServerFunc>([
   ['listWorkspaces', listWorkspaces],
   ['createWorkspace', createWorkspace],
   ['setActiveWorkspace', setActiveWorkspace],
+  ['renameWorkspace', renameWorkspace],
+  ['deleteWorkspace', deleteWorkspace],
+  ['countConnectionsByWorkspace', countConnectionsByWorkspace],
 ]);

--- a/libs/messages/messages-db/src/index.ts
+++ b/libs/messages/messages-db/src/index.ts
@@ -23,3 +23,40 @@ export function switchMessagesDbWorkspace(workspaceId: UUID): void {
   switchDatabaseWorkspace(workspaceId);
   repositoryPromise = undefined;
 }
+
+/** Returns the number of message pages owned by the given workspace. */
+export async function countPagesByWorkspace(workspaceId: UUID): Promise<number> {
+  const db = await getPagesDb();
+  return db.countPagesByWorkspace(workspaceId);
+}
+
+/**
+ * Deletes all data owned by the given workspace:
+ * - Removes all page rows from the shared SQLite pages table.
+ * - Drops the sqlite/{workspaceId}/ OPFS directory and all message files inside it.
+ * - Removes the workspace entry from the pagesOrder localStorage key.
+ */
+export async function deleteWorkspaceData(workspaceId: UUID): Promise<void> {
+  const db = await getPagesDb();
+  await db.deletePagesByWorkspace(workspaceId);
+
+  await dropWorkspaceOpfsDirectory(workspaceId);
+
+  const PAGES_ORDER_KEY = 'pagesOrder';
+  const stored = localStorage.getItem(PAGES_ORDER_KEY);
+  if (stored) {
+    const parsed = JSON.parse(stored);
+    delete parsed[workspaceId];
+    localStorage.setItem(PAGES_ORDER_KEY, JSON.stringify(parsed));
+  }
+}
+
+async function dropWorkspaceOpfsDirectory(workspaceId: UUID): Promise<void> {
+  try {
+    const opfsRoot = await navigator.storage.getDirectory();
+    const sqliteRoot = await opfsRoot.getDirectoryHandle('sqlite');
+    await sqliteRoot.removeEntry(workspaceId, { recursive: true });
+  } catch {
+    // Directory may not exist if the workspace had no message pages.
+  }
+}

--- a/libs/messages/messages-db/src/lib/pages-database.ts
+++ b/libs/messages/messages-db/src/lib/pages-database.ts
@@ -8,4 +8,6 @@ export type PagesDatabase = {
   getPage(id: UUID): Promise<Page | undefined>;
   updatePageName(id: UUID, name: string): Promise<void>;
   closePage(id: UUID): Promise<void>;
+  countPagesByWorkspace(workspaceId: UUID): Promise<number>;
+  deletePagesByWorkspace(workspaceId: UUID): Promise<void>;
 }

--- a/libs/messages/messages-db/src/lib/sqlite-pages.database.ts
+++ b/libs/messages/messages-db/src/lib/sqlite-pages.database.ts
@@ -62,6 +62,21 @@ export class SqlitePagesDatabase implements PagesDatabase {
     );
   }
 
+  async countPagesByWorkspace(workspaceId: UUID): Promise<number> {
+    const rows = await this.selectRows<[number]>(
+      'SELECT COUNT(*) FROM pages WHERE workspaceId = ?',
+      [workspaceId],
+    );
+    return rows[0]?.[0] ?? 0;
+  }
+
+  async deletePagesByWorkspace(workspaceId: UUID): Promise<void> {
+    await this.database.exec(
+      `DELETE FROM pages WHERE workspaceId = ?`,
+      [workspaceId],
+    );
+  }
+
   private async selectRows<T>(sql: string, args: unknown[] = []): Promise<T[]> {
     const response = await this.database.exec(sql, args);
     const responseAsRecord = response as {

--- a/libs/shared/services/src/lib/workspace.service.ts
+++ b/libs/shared/services/src/lib/workspace.service.ts
@@ -64,4 +64,23 @@ export class WorkspaceService {
     this.addWorkspace(workspace);
     return workspace;
   }
+
+  async renameWorkspace(id: UUID, name: string): Promise<void> {
+    await this.workspacesClient.renameWorkspace(id, name);
+    this._availableWorkspaces.update((ws) =>
+      ws.map((w) => (w.id === id ? { ...w, name } : w)),
+    );
+    if (this._activeWorkspace()?.id === id) {
+      this._activeWorkspace.update((w) => (w ? { ...w, name } : w));
+    }
+  }
+
+  async deleteWorkspace(id: UUID): Promise<void> {
+    await this.workspacesClient.deleteWorkspace(id);
+    this._availableWorkspaces.update((ws) => ws.filter((w) => w.id !== id));
+  }
+
+  async countConnectionsByWorkspace(id: UUID): Promise<number> {
+    return this.workspacesClient.countConnectionsByWorkspace(id);
+  }
 }


### PR DESCRIPTION
## Summary

- **Rename**: ✏ icon on the active workspace row opens a pre-filled dialog. Submitting updates the `name` field only — the workspace `id`, avatar colour (derived from id), and all owned records are untouched.
- **Delete**: 🗑 icon rendered only on non-active workspace rows. Disabled (with tooltip) when only one workspace exists. Opening the dialog immediately fires parallel requests to count connections (backend) and page count (SQLite) to show the user exactly what will be destroyed.
- **Cascade deletion on confirm**: removes all connections with that `workspaceId` from `sbb-connections.json`, removes the workspace from `sbb-workspaces.json`, deletes all `pages` rows with that `workspaceId` from the shared SQLite database, drops the `sqlite/{workspaceId}/` OPFS directory (all stored messages), and removes the workspace key from `pagesOrder` in localStorage.
- **Web variant**: handles rename/delete against localStorage; `countConnectionsByWorkspace` returns 0 (web connections aren't tracked by workspace id server-side).

## Files changed

| Layer | File |
|---|---|
| Server interface | `libs/backend/server/src/lib/workspaces/types.ts` |
| Server actions | `libs/backend/server/src/lib/workspaces/workspaces-actions.ts` |
| Electron storage | `apps/servicebus-browser-app/src/app/events/secure-storage/workspace-storage.ts` |
| Pages DB interface | `libs/messages/messages-db/src/lib/pages-database.ts` |
| Pages DB impl | `libs/messages/messages-db/src/lib/sqlite-pages.database.ts` |
| messages-db public API | `libs/messages/messages-db/src/index.ts` |
| Frontend client | `libs/api-clients/clients/src/lib/workspaces-frontend-client.ts` |
| Web backend | `libs/api-clients/angular-bindings/src/web-backend-api.ts` |
| WorkspaceService | `libs/shared/services/src/lib/workspace.service.ts` |
| Switcher component | `apps/servicebus-browser-frontend/src/app/main-shell/workspace-switcher/workspace-switcher.ts` |
| Switcher template | `apps/servicebus-browser-frontend/src/app/main-shell/workspace-switcher/workspace-switcher.html` |
| Switcher styles | `apps/servicebus-browser-frontend/src/app/main-shell/workspace-switcher/workspace-switcher.scss` |

## Test plan

- [ ] Rename the active workspace — verify the new name appears in the trigger button, avatar colour is unchanged, and connections/pages still work.
- [ ] Try to rename to an empty string — the Rename button should stay disabled.
- [ ] With only one workspace: verify the 🗑 button is absent from all rows (no non-active rows to show it on).
- [ ] Create a second workspace with connections and message pages; switch away; open delete dialog on the original — verify counts match.
- [ ] Confirm deletion — verify the workspace is gone from the switcher, its connections are absent when switching back, and no orphan OPFS files remain.
- [ ] Regression: workspace creation (#143) and switching (#144) still work as before.

Closes #145

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ability to rename workspaces with a new dialog interface.
  * Added ability to delete workspaces with confirmation dialog showing impact (connections and messages to be removed).
  * Enhanced workspace management UI with action buttons for rename and delete operations.
  * Improved workspace and connection data persistence with separate encrypted storage.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mligtenberg/ServicebusBrowser/pull/152?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->