### PR TITLE
feat(workspaces): web config nested workspaces + versioned schema (issue #146)

### DIFF
--- a/apps/servicebus-browser-web-backend/src/config-file-workspace-store.ts
+++ b/apps/servicebus-browser-web-backend/src/config-file-workspace-store.ts
@@ -1,0 +1,59 @@
+import { UUID, Workspace } from '@service-bus-browser/shared-contracts';
+import { WorkspaceStore } from '@service-bus-browser/service-bus-server';
+import { ParsedConfig } from './web-config-loader';
+
+/**
+ * Read-only WorkspaceStore backed by a static parsed config file.
+ * Mutations (create/rename/delete) are not supported on the web backend —
+ * the operator edits the config file directly.
+ *
+ * setActiveWorkspaceId is the one mutable operation: it updates an in-memory
+ * holder so the connection store can filter connections accordingly.
+ */
+export class ConfigFileWorkspaceStore implements WorkspaceStore {
+  private readonly workspaces: Workspace[];
+
+  constructor(
+    private readonly config: ParsedConfig,
+    private readonly activeWorkspaceHolder: { id: UUID },
+  ) {
+    this.workspaces = config.workspaces.map((ws) => ({
+      id: ws.id,
+      name: ws.name,
+      createdAt: new Date(0).toISOString(),
+    }));
+  }
+
+  listWorkspaces(): Workspace[] {
+    return this.workspaces;
+  }
+
+  setActiveWorkspaceId(id: UUID): void {
+    const exists = this.workspaces.some((ws) => ws.id === id);
+    if (!exists) {
+      throw new Error(`Workspace with id "${id}" not found.`);
+    }
+    this.activeWorkspaceHolder.id = id;
+  }
+
+  countConnectionsByWorkspace(id: UUID): number {
+    const ws = this.config.workspaces.find((w) => w.id === id);
+    return ws?.connections.length ?? 0;
+  }
+
+  createWorkspace(): void {
+    throw new Error('Web backend is read-only: edit the config file to add workspaces.');
+  }
+
+  renameWorkspace(): void {
+    throw new Error('Web backend is read-only: edit the config file to rename workspaces.');
+  }
+
+  deleteWorkspace(): void {
+    throw new Error('Web backend is read-only: edit the config file to delete workspaces.');
+  }
+
+  deleteConnectionsByWorkspace(): void {
+    throw new Error('Web backend is read-only: edit the config file to delete connections.');
+  }
+}

--- a/apps/servicebus-browser-web-backend/src/main.ts
+++ b/apps/servicebus-browser-web-backend/src/main.ts
@@ -5,13 +5,25 @@
 
 import express from 'express';
 import * as path from 'path';
-import { Server } from '@service-bus-browser/service-bus-server';
+import { Server, WorkspacesServer } from '@service-bus-browser/service-bus-server';
 import { ReadonlyConfigFileConnectionStorage } from './readonly-config-file-connection-store';
+import { ConfigFileWorkspaceStore } from './config-file-workspace-store';
+import { loadConfig } from './web-config-loader';
 import bp from 'body-parser';
 import { getOidcConfig, validateJWT } from './validate-tokens';
-import { BSON, EJSON } from 'bson';
+import { BSON } from 'bson';
+import { UUID } from '@service-bus-browser/shared-contracts';
 
-const serviceBusBrowserServer = new Server(new ReadonlyConfigFileConnectionStorage());
+const configPath = `${process.cwd()}/sbb-connections.json`;
+const config = loadConfig(configPath);
+
+const activeWorkspaceHolder = { id: config.workspaces[0].id as UUID };
+
+const connectionStorage = new ReadonlyConfigFileConnectionStorage(config, activeWorkspaceHolder);
+const workspaceStore = new ConfigFileWorkspaceStore(config, activeWorkspaceHolder);
+
+const serviceBusBrowserServer = new Server(connectionStorage);
+const workspacesServer = new WorkspacesServer(workspaceStore);
 
 const app = express();
 
@@ -22,6 +34,21 @@ app.get('/api/client-config', async (_, res) => {
   const oidcConfig = await getOidcConfig();
 
   res.status(200).json(oidcConfig.clientConfig);
+});
+
+app.post('/api/workspaces/command', async (req, res) => {
+  const token = req.headers.authorization?.split(' ')[1];
+  if (!token || !(await validateJWT(token))) {
+    res.status(401).send('Unauthorized');
+    return;
+  }
+
+  const request: { requestType: string; body: unknown } = req.body;
+
+  const result = await workspacesServer.workspacesExecute(request.requestType, request.body);
+  const bsonData = BSON.serialize({ result: result ?? null });
+  res.setHeader('Content-Type', 'application/bson');
+  res.send(Buffer.from(bsonData));
 });
 
 app.post('/api/messages/command', async (req, res) => {

--- a/apps/servicebus-browser-web-backend/src/readonly-config-file-connection-store.ts
+++ b/apps/servicebus-browser-web-backend/src/readonly-config-file-connection-store.ts
@@ -1,47 +1,37 @@
 import { Connection } from '@service-bus-browser/api-contracts';
 import { UUID } from '@service-bus-browser/shared-contracts';
-import * as fs from 'fs';
 import { ConnectionStore } from '@service-bus-browser/service-bus-server';
+import { ParsedConfig } from './web-config-loader';
 
 export class ReadonlyConfigFileConnectionStorage implements ConnectionStore {
-  connectionsPath: string;
+  constructor(
+    private readonly config: ParsedConfig,
+    private readonly activeWorkspaceHolder: { id: UUID },
+  ) {}
 
-  constructor() {
-    this.connectionsPath = `${process.cwd()}/sbb-connections.json`;
-  }
-
-  addConnection(connection: Connection): void {
+  addConnection(_connection: Connection): void {
     throw new Error('Method not implemented. This class is read-only.');
   }
 
-  removeConnection(connectionId: UUID): void {
+  removeConnection(_connectionId: UUID): void {
     throw new Error('Method not implemented. This class is read-only.');
   }
 
   listConnections(): Array<{ connectionId: UUID; connectionName: string }> {
-    const connections = this.readCurrentConnections();
-    return Object.entries(connections).map(([connectionId, connection]) => ({
-      connectionId: connectionId as UUID,
-      connectionName: connection.name,
+    return this.activeWorkspaceConnections().map((c) => ({
+      connectionId: c.id,
+      connectionName: c.name,
     }));
   }
 
   getConnection(connectionId: UUID): Connection | undefined {
-    const connections = this.readCurrentConnections();
-    return connections[connectionId];
+    return this.activeWorkspaceConnections().find((c) => c.id === connectionId);
   }
 
-  private readCurrentConnections(): Record<UUID, Connection> {
-    if (fs.existsSync(this.connectionsPath)) {
-      const fileContent = fs.readFileSync(this.connectionsPath, 'utf8');
-      const connections: Connection[] = JSON.parse(fileContent);
-
-      return connections.reduce<Record<UUID, Connection>>((acc, connection) => {
-        acc[connection.id] = connection;
-        return acc;
-      }, {});
-    }
-
-    return {};
+  private activeWorkspaceConnections(): Connection[] {
+    const ws = this.config.workspaces.find(
+      (w) => w.id === this.activeWorkspaceHolder.id,
+    );
+    return ws?.connections ?? [];
   }
 }

--- a/apps/servicebus-browser-web-backend/src/web-config-loader.ts
+++ b/apps/servicebus-browser-web-backend/src/web-config-loader.ts
@@ -1,0 +1,153 @@
+import { Connection } from '@service-bus-browser/api-contracts';
+import { UUID } from '@service-bus-browser/shared-contracts';
+import * as fs from 'fs';
+
+const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+function isValidUuid(value: unknown): value is UUID {
+  return typeof value === 'string' && UUID_REGEX.test(value);
+}
+
+export interface WorkspaceConfig {
+  id: UUID;
+  name: string;
+  connections: Connection[];
+}
+
+export interface ParsedConfig {
+  workspaces: WorkspaceConfig[];
+}
+
+export function loadConfig(configPath: string): ParsedConfig {
+  if (!fs.existsSync(configPath)) {
+    console.warn(`Config file not found at ${configPath}; starting with empty workspace.`);
+    return {
+      workspaces: [
+        {
+          id: crypto.randomUUID() as UUID,
+          name: 'Default',
+          connections: [],
+        },
+      ],
+    };
+  }
+
+  const raw = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+
+  if (Array.isArray(raw)) {
+    // Legacy flat format: wrap into a single "Default" workspace.
+    console.warn(
+      `[DEPRECATION] Config file at ${configPath} uses the legacy flat-connections format. ` +
+        `Migrate to the versioned workspace format: { "version": 1, "workspaces": [...] }`,
+    );
+    const connections = raw as Connection[];
+    return {
+      workspaces: [
+        {
+          id: crypto.randomUUID() as UUID,
+          name: 'Default',
+          connections,
+        },
+      ],
+    };
+  }
+
+  if (typeof raw !== 'object' || raw === null) {
+    throw new Error(`Config file at ${configPath} is not a valid JSON object or array.`);
+  }
+
+  if (!('version' in raw)) {
+    console.warn(
+      `[DEPRECATION] Config file at ${configPath} is missing the "version" field. ` +
+        `Treating all connections as a single "Default" workspace. ` +
+        `Migrate to: { "version": 1, "workspaces": [...] }`,
+    );
+    const connections: Connection[] = (raw as { connections?: Connection[] }).connections ?? [];
+    return {
+      workspaces: [
+        {
+          id: crypto.randomUUID() as UUID,
+          name: 'Default',
+          connections,
+        },
+      ],
+    };
+  }
+
+  const versioned = raw as { version: unknown; workspaces: unknown };
+
+  if (versioned.version !== 1) {
+    throw new Error(
+      `Config file at ${configPath} has unsupported version ${versioned.version}. Only version 1 is supported.`,
+    );
+  }
+
+  if (!Array.isArray(versioned.workspaces)) {
+    throw new Error(`Config file at ${configPath}: "workspaces" must be an array.`);
+  }
+
+  const workspaceIds = new Set<string>();
+  const connectionIds = new Set<string>();
+  const workspaces: WorkspaceConfig[] = [];
+
+  for (let i = 0; i < versioned.workspaces.length; i++) {
+    const ws = versioned.workspaces[i] as Record<string, unknown>;
+
+    if (!isValidUuid(ws['id'])) {
+      throw new Error(
+        `Config file at ${configPath}: workspace[${i}] has missing or invalid "id" (must be a UUID).`,
+      );
+    }
+    if (typeof ws['name'] !== 'string' || ws['name'].trim() === '') {
+      throw new Error(
+        `Config file at ${configPath}: workspace[${i}] has missing or empty "name".`,
+      );
+    }
+
+    if (workspaceIds.has(ws['id'])) {
+      throw new Error(
+        `Config file at ${configPath}: duplicate workspace id "${ws['id']}".`,
+      );
+    }
+    workspaceIds.add(ws['id'] as string);
+
+    const rawConnections = ws['connections'];
+    if (!Array.isArray(rawConnections)) {
+      throw new Error(
+        `Config file at ${configPath}: workspace[${i}] "connections" must be an array.`,
+      );
+    }
+
+    const connections: Connection[] = [];
+    for (let j = 0; j < rawConnections.length; j++) {
+      const conn = rawConnections[j] as Record<string, unknown>;
+      if (!isValidUuid(conn['id'])) {
+        throw new Error(
+          `Config file at ${configPath}: workspace[${i}].connections[${j}] has missing or invalid "id".`,
+        );
+      }
+      if (connectionIds.has(conn['id'] as string)) {
+        throw new Error(
+          `Config file at ${configPath}: duplicate connection id "${conn['id']}" (connection ids must be unique across all workspaces).`,
+        );
+      }
+      connectionIds.add(conn['id'] as string);
+      connections.push(conn as unknown as Connection);
+    }
+
+    const extraKeys = Object.keys(ws).filter((k) => !['id', 'name', 'connections'].includes(k));
+    if (extraKeys.length > 0) {
+      console.warn(
+        `Config file at ${configPath}: workspace[${i}] has unknown fields [${extraKeys.join(', ')}] — ignoring.`,
+      );
+    }
+
+    workspaces.push({
+      id: ws['id'] as UUID,
+      name: (ws['name'] as string).trim(),
+      connections,
+    });
+  }
+
+  return { workspaces };
+}

--- a/apps/servicebus-browser-web-frontend/src/app/app.config.ts
+++ b/apps/servicebus-browser-web-frontend/src/app/app.config.ts
@@ -1,8 +1,6 @@
 import {
   ApplicationConfig,
-  inject,
   isDevMode,
-  provideAppInitializer,
   provideZonelessChangeDetection,
 } from '@angular/core';
 import {
@@ -36,31 +34,9 @@ import {
 import { ClientConfigStsLoader } from './auth-config';
 import { provideMonacoConfig } from '@service-bus-browser/shared-components';
 import { DialogService } from 'primeng/dynamicdialog';
-import { WorkspaceService } from '@service-bus-browser/services';
-import { initializeWorkspace, migrateOpfsFiles, getMessagesRepository } from '@service-bus-browser/messages-db';
-import { WorkspacesFrontendClient } from '@service-bus-browser/service-bus-frontend-clients';
 
 export const appConfig: ApplicationConfig = {
   providers: [
-    // workspace initialization — must complete before NgRx effects start
-    provideAppInitializer(async () => {
-      const workspaceService = inject(WorkspaceService);
-      const workspacesClient = inject(WorkspacesFrontendClient);
-
-      const workspaces = await workspacesClient.listWorkspaces();
-      const workspace = workspaceService.initialize(workspaces);
-
-      try {
-        await migrateOpfsFiles(workspace.id);
-      } catch (err) {
-        console.warn('OPFS migration failed; will retry on next boot:', err);
-      }
-      initializeWorkspace(workspace.id);
-      // Force module-level `repository` bindings (set via getMessagesRepository().then(...))
-      // to be assigned before NgRx effects run.
-      await getMessagesRepository();
-    }),
-
     // oidc auth
     provideAuth(
       {

--- a/apps/servicebus-browser-web-frontend/src/app/main-app/main-app.html
+++ b/apps/servicebus-browser-web-frontend/src/app/main-app/main-app.html
@@ -1,17 +1,23 @@
-<lib-main-ui
-  [menuItems]="menuItems"
->
-  <ng-template #menuEnd>
-    <div class="account">
-      <p-button
-        [text]="true"
-        class="name-button"
-        severity="secondary"
-        icon="pi pi-user"
-        [label]="userName()"
-        (click)="accountMenu.toggle($event)"/>
+@defer (when workspacesInitialized()) {
+  <lib-main-ui
+    [menuItems]="menuItems"
+  >
+    <ng-template #menuStart>
+      <app-workspace-switcher />
+    </ng-template>
 
-      <p-menu #accountMenu [model]="accountMenuItems" [popup]="true" />
-    </div>
-  </ng-template>
-</lib-main-ui>
+    <ng-template #menuEnd>
+      <div class="account">
+        <p-button
+          [text]="true"
+          class="name-button"
+          severity="secondary"
+          icon="pi pi-user"
+          [label]="userName()"
+          (click)="accountMenu.toggle($event)"/>
+
+        <p-menu #accountMenu [model]="accountMenuItems" [popup]="true" />
+      </div>
+    </ng-template>
+  </lib-main-ui>
+}

--- a/apps/servicebus-browser-web-frontend/src/app/main-app/main-app.ts
+++ b/apps/servicebus-browser-web-frontend/src/app/main-app/main-app.ts
@@ -1,4 +1,4 @@
-import { Component, computed, inject } from '@angular/core';
+import { Component, computed, inject, OnInit, signal } from '@angular/core';
 
 import { Button } from 'primeng/button';
 import { MainUiComponent } from '@service-bus-browser/main-ui';
@@ -8,21 +8,28 @@ import { Store } from '@ngrx/store';
 import { OidcSecurityService } from 'angular-auth-oidc-client';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { map } from 'rxjs';
-import { ColorThemeService } from '@service-bus-browser/services';
+import { ColorThemeService, WorkspaceService } from '@service-bus-browser/services';
 import { messagesActions } from '@service-bus-browser/messages-store';
+import { WorkspaceSwitcherComponent } from './workspace-switcher/workspace-switcher';
+import { WorkspacesFrontendClient } from '@service-bus-browser/service-bus-frontend-clients';
+import { initializeWorkspace, migrateOpfsFiles, getMessagesRepository } from '@service-bus-browser/messages-db';
 
 @Component({
   selector: 'app-main-app',
-  imports: [Button, MainUiComponent, Menu],
+  imports: [Button, MainUiComponent, Menu, WorkspaceSwitcherComponent],
   templateUrl: './main-app.html',
   styleUrl: './main-app.scss',
 })
-export class MainApp {
+export class MainApp implements OnInit {
   private oidcSecurityService = inject(OidcSecurityService);
   private themeService = inject(ColorThemeService);
+  private workspaceService = inject(WorkspaceService);
+  private workspacesClient = inject(WorkspacesFrontendClient);
 
   protected title = 'Service Bus Browser';
   private readonly store = inject(Store);
+
+  workspacesInitialized = signal(false);
 
   userData = toSignal(
     this.oidcSecurityService.userData$.pipe(map((r) => r.userData)),
@@ -89,6 +96,24 @@ export class MainApp {
       },
     },
   ];
+
+  async ngOnInit(): Promise<void> {
+    // Auth is confirmed by AutoLoginPartialRoutesGuard before this component
+    // renders, so the token is available for these HTTP calls.
+    const workspaces = await this.workspacesClient.listWorkspaces();
+    const workspace = this.workspaceService.initialize(workspaces);
+    await this.workspacesClient.setActiveWorkspaceId(workspace.id);
+
+    try {
+      await migrateOpfsFiles(workspace.id);
+    } catch (err) {
+      console.warn('OPFS migration failed; will retry on next boot:', err);
+    }
+    initializeWorkspace(workspace.id);
+    await getMessagesRepository();
+
+    this.workspacesInitialized.set(true);
+  }
 
   importMessages(): void {
     this.store.dispatch(messagesActions.startImportMessages());

--- a/apps/servicebus-browser-web-frontend/src/app/main-app/workspace-switcher/workspace-switcher.html
+++ b/apps/servicebus-browser-web-frontend/src/app/main-app/workspace-switcher/workspace-switcher.html
@@ -1,0 +1,66 @@
+<button
+  class="ws-trigger"
+  (click)="togglePopover($event)"
+  type="button"
+>
+  @if (activeWorkspace(); as ws) {
+    <span class="ws-avatar" [ngStyle]="{ 'background-color': activeColor() }">
+      {{ activeInitials() }}
+    </span>
+    <span class="ws-name">{{ ws.name }}</span>
+    <span class="pi pi-chevron-down ws-chevron"></span>
+  }
+</button>
+
+<p-popover #op styleClass="ws-popover">
+  <div class="ws-dropdown">
+    <div class="ws-section-label">Active</div>
+    @if (activeWorkspace(); as ws) {
+      <div class="ws-row ws-row--active">
+        <span class="ws-avatar ws-avatar--sm" [ngStyle]="{ 'background-color': avatarColor(ws) }">
+          {{ initials(ws) }}
+        </span>
+        <span class="ws-row-name">{{ ws.name }}</span>
+      </div>
+    }
+
+    @if (otherWorkspaces().length > 0) {
+      <div class="ws-separator"></div>
+      <div class="ws-section-label">Workspaces</div>
+      @for (ws of otherWorkspaces(); track ws.id) {
+        <button class="ws-row ws-row--clickable" type="button" (click)="selectWorkspace(ws)">
+          <span class="ws-avatar ws-avatar--sm" [ngStyle]="{ 'background-color': avatarColor(ws) }">
+            {{ initials(ws) }}
+          </span>
+          <span class="ws-row-name">{{ ws.name }}</span>
+        </button>
+      }
+    }
+  </div>
+</p-popover>
+
+<p-dialog
+  header="Switch Workspace"
+  [visible]="showConfirmDialog()"
+  (visibleChange)="!$event && cancelSwitch()"
+  [modal]="true"
+  [style]="{ width: '420px' }"
+  [draggable]="false"
+>
+  <p class="confirm-text">
+    One or more message loads are currently in progress. Switching workspaces
+    will cancel all active loads. Do you want to continue?
+  </p>
+  <ng-template #footer>
+    <p-button
+      label="Cancel"
+      severity="secondary"
+      (click)="cancelSwitch()"
+    />
+    <p-button
+      label="Continue"
+      severity="danger"
+      (click)="confirmSwitch()"
+    />
+  </ng-template>
+</p-dialog>

--- a/apps/servicebus-browser-web-frontend/src/app/main-app/workspace-switcher/workspace-switcher.scss
+++ b/apps/servicebus-browser-web-frontend/src/app/main-app/workspace-switcher/workspace-switcher.scss
@@ -1,0 +1,111 @@
+.ws-trigger {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  padding: 4px 8px;
+  border-radius: 6px;
+  color: inherit;
+
+  &:hover {
+    background: rgba(255, 255, 255, 0.08);
+  }
+}
+
+.ws-avatar {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border-radius: 6px;
+  font-size: 11px;
+  font-weight: 600;
+  color: #fff;
+  flex-shrink: 0;
+
+  &.ws-avatar--sm {
+    width: 22px;
+    height: 22px;
+    font-size: 9px;
+    border-radius: 4px;
+  }
+}
+
+.ws-name {
+  font-size: 13px;
+  font-weight: 500;
+  max-width: 140px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.ws-chevron {
+  font-size: 10px;
+  opacity: 0.6;
+}
+
+:host ::ng-deep .ws-popover .p-popover-content {
+  padding: 6px 0;
+  min-width: 220px;
+}
+
+.ws-dropdown {
+  display: flex;
+  flex-direction: column;
+}
+
+.ws-section-label {
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  opacity: 0.5;
+  padding: 4px 12px 2px;
+}
+
+.ws-separator {
+  height: 1px;
+  background: rgba(128, 128, 128, 0.2);
+  margin: 4px 0;
+}
+
+.ws-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 12px;
+
+  &.ws-row--active {
+    background: rgba(128, 128, 128, 0.08);
+  }
+
+  &.ws-row--clickable {
+    background: transparent;
+    border: none;
+    cursor: pointer;
+    width: 100%;
+    text-align: left;
+    color: inherit;
+
+    &:hover {
+      background: rgba(128, 128, 128, 0.1);
+    }
+  }
+}
+
+.ws-row-name {
+  flex: 1;
+  font-size: 13px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.confirm-text {
+  margin: 0;
+  line-height: 1.5;
+}

--- a/apps/servicebus-browser-web-frontend/src/app/main-app/workspace-switcher/workspace-switcher.ts
+++ b/apps/servicebus-browser-web-frontend/src/app/main-app/workspace-switcher/workspace-switcher.ts
@@ -1,0 +1,109 @@
+import {
+  Component,
+  computed,
+  inject,
+  signal,
+  ViewChild,
+} from '@angular/core';
+import { NgStyle } from '@angular/common';
+import { Popover } from 'primeng/popover';
+import { Dialog } from 'primeng/dialog';
+import { Button } from 'primeng/button';
+import { WorkspaceService } from '@service-bus-browser/services';
+import { WorkspaceSwitchService } from '../../workspace-switch.service';
+import { Workspace } from '@service-bus-browser/shared-contracts';
+import { Store } from '@ngrx/store';
+import { TasksSelectors } from '@service-bus-browser/tasks-store';
+
+function workspaceAvatarColor(id: string): string {
+  let hash = 0;
+  for (let i = 0; i < id.length; i++) {
+    hash = (hash * 31 + id.charCodeAt(i)) >>> 0;
+  }
+  const hue = hash % 360;
+  return `hsl(${hue}, 55%, 45%)`;
+}
+
+function workspaceInitials(name: string): string {
+  const words = name.trim().split(/\s+/);
+  if (words.length >= 2) {
+    return (words[0][0] + words[1][0]).toUpperCase();
+  }
+  return name.substring(0, 2).toUpperCase();
+}
+
+@Component({
+  selector: 'app-workspace-switcher',
+  standalone: true,
+  imports: [NgStyle, Popover, Dialog, Button],
+  templateUrl: './workspace-switcher.html',
+  styleUrl: './workspace-switcher.scss',
+})
+export class WorkspaceSwitcherComponent {
+  @ViewChild('op') popover!: Popover;
+
+  private readonly store = inject(Store);
+  workspaceService = inject(WorkspaceService);
+  switchService = inject(WorkspaceSwitchService);
+
+  activeWorkspace = this.workspaceService.activeWorkspace;
+  availableWorkspaces = this.workspaceService.availableWorkspaces;
+
+  activeTasks = this.store.selectSignal(TasksSelectors.selectTasks);
+  hasActiveTasks = computed(() => this.activeTasks().length > 0);
+
+  activeColor = computed(() => {
+    const ws = this.activeWorkspace();
+    return ws ? workspaceAvatarColor(ws.id) : '#888';
+  });
+
+  activeInitials = computed(() => {
+    const ws = this.activeWorkspace();
+    return ws ? workspaceInitials(ws.name) : '??';
+  });
+
+  otherWorkspaces = computed(() => {
+    const active = this.activeWorkspace();
+    return this.availableWorkspaces()
+      .filter((w) => w.id !== active?.id)
+      .sort((a, b) => a.name.localeCompare(b.name));
+  });
+
+  showConfirmDialog = signal(false);
+  pendingWorkspace = signal<Workspace | null>(null);
+
+  avatarColor(ws: Workspace): string {
+    return workspaceAvatarColor(ws.id);
+  }
+
+  initials(ws: Workspace): string {
+    return workspaceInitials(ws.name);
+  }
+
+  togglePopover(event: Event): void {
+    this.popover.toggle(event);
+  }
+
+  selectWorkspace(ws: Workspace): void {
+    this.popover.hide();
+    if (this.hasActiveTasks()) {
+      this.pendingWorkspace.set(ws);
+      this.showConfirmDialog.set(true);
+    } else {
+      this.switchService.switchTo(ws);
+    }
+  }
+
+  async confirmSwitch(): Promise<void> {
+    const ws = this.pendingWorkspace();
+    if (!ws) return;
+    this.showConfirmDialog.set(false);
+    this.pendingWorkspace.set(null);
+    await this.switchService.switchTo(ws);
+  }
+
+  cancelSwitch(): void {
+    this.showConfirmDialog.set(false);
+    this.pendingWorkspace.set(null);
+  }
+}

--- a/apps/servicebus-browser-web-frontend/src/app/workspace-switch.service.ts
+++ b/apps/servicebus-browser-web-frontend/src/app/workspace-switch.service.ts
@@ -1,0 +1,29 @@
+import { inject, Injectable } from '@angular/core';
+import { Store } from '@ngrx/store';
+import { Workspace } from '@service-bus-browser/shared-contracts';
+import { WorkspaceService } from '@service-bus-browser/services';
+import { messagePagesEffectActions } from '@service-bus-browser/messages-store';
+import { switchMessagesDbWorkspace } from '@service-bus-browser/messages-db';
+import { pagesActions } from '@service-bus-browser/main-ui';
+import { TopologyActions } from '@service-bus-browser/topology-store';
+import { TasksActions } from '@service-bus-browser/tasks-store';
+
+/**
+ * Coordinates a full workspace switch for the web variant: persists the active
+ * workspace, resets the messages-db cache, and tears down + rehydrates all
+ * NgRx stores.
+ */
+@Injectable({ providedIn: 'root' })
+export class WorkspaceSwitchService {
+  private readonly store = inject(Store);
+  private readonly workspaceService = inject(WorkspaceService);
+
+  async switchTo(workspace: Workspace): Promise<void> {
+    this.store.dispatch(TasksActions.cancelAllTasks());
+    await this.workspaceService.setActive(workspace);
+    switchMessagesDbWorkspace(workspace.id);
+    this.store.dispatch(messagePagesEffectActions.workspaceSwitched());
+    this.store.dispatch(pagesActions.loadPageOrderFromStorage({ orderOverrides: {} }));
+    this.store.dispatch(TopologyActions.loadTopologyRootNodes());
+  }
+}

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,6 +2,10 @@
 
 Welcome to the documentation for Servicebus Browser. This repository contains information about the architecture, development workflows, and technical details of the project.
 
+## Getting Started
+
+- [Quickstart: Web Version](./quickstart-webversion.md): Step-by-step guide to configure and run the web variant, including the `sbb-connections.json` workspace/connection format and Docker run command.
+
 ## Architecture & Design
 
 - [Frontend-Backend Communication](./frontend-backend-communication.md): Details on how the Angular UI communicates with backends via the `ApiHandler` abstraction.

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,6 +10,7 @@ Welcome to the documentation for Servicebus Browser. This repository contains in
 - [Web App Build Process](./web-app-build-process.md): Instructions for building, containerizing, and deploying the web application.
 - [Event Hub Namespace REST Authentication](./event-hub-namespace-rest-auth.md): SAS token generation and API versioning for Event Hub namespace management calls.
 - [Messages Reader Continuation Token Behavior](./messages-reader-continuation-token-behavior.md): Cross-broker continuation-token rules to stop message loading exactly at requested limits.
+- [Web Backend Config Format](./web-config-format.md): Versioned workspace+connection config file consumed by the web backend, legacy auto-migration, and validation rules.
 
 ## Architecture Decision Records
 

--- a/docs/quickstart-webversion.md
+++ b/docs/quickstart-webversion.md
@@ -1,27 +1,29 @@
 # Quickstart Guide for Web Version
 
 ## Creating the app registration
-create a new app registration in the Azure portal with the following settings:
+Create a new app registration in the Azure portal with the following settings:
 - Authentication:
-  - platform type: Single-page application
+  - Platform type: Single-page application
   - Redirect URI: `https://<service-bus-browser-hostname>`
 
-It is recommended to enable the "assignment required" in the connected enterprise applications settings.
+It is recommended to enable "Assignment required" in the connected enterprise application settings.
 To do this:
-- navigate to the enterprise application via the overview page of the app registration.  
-- Select the link under the "Managed application in local directory" header
-- In the "Properties" section, set "User assignment required?" to "Yes"
+- Navigate to the enterprise application via the overview page of the app registration.
+- Select the link under the "Managed application in local directory" header.
+- In the "Properties" section, set "User assignment required?" to "Yes".
 
 ## Configure the app
-Create a file called `sbb-connections.json`. This file contains an array with the connections provided in the web UI.
-Create a second file called `openid-config.json`. This file is directly passed to the [`angular-auth-oidc-client`](https://angular-auth-oidc-client.com/) library.
-Reference their [documentation](https://angular-auth-oidc-client.com/docs/documentation/configuration) for information on how to configure the file.
 
-Use the following template if you want to use Microsoft Entra:
+Create two files before running the container:
+
+### `openid-config.json`
+Passed directly to the [`angular-auth-oidc-client`](https://angular-auth-oidc-client.com/) library.
+See their [configuration docs](https://angular-auth-oidc-client.com/docs/documentation/configuration) for all options.
+
+Template for Microsoft Entra:
 ```json
 {
-  "authority":
-  "https://login.microsoftonline.com/{tenantId}/v2.0",
+  "authority": "https://login.microsoftonline.com/{tenantId}/v2.0",
   "clientId": "{clientId}",
   "scope": "openid profile api://{clientId}/access",
   "responseType": "code",
@@ -35,99 +37,120 @@ Use the following template if you want to use Microsoft Entra:
     "prompt": "select_account"
   }
 }
-
 ```
-For this to work, make sure you configured the access permissions in the app registration.
-And make sure the `requestedAccessTokenVersion` in the app registration manifest is set to `2`.
+Make sure the `requestedAccessTokenVersion` in the app registration manifest is set to `2`.
 
+### `sbb-connections.json`
+Defines the workspaces and connections shown in the UI. The operator owns this file — the web frontend is read-only and cannot create, rename, or delete workspaces.
 
-The different connection types are:
-
-Service Bus - connection string:
+#### Format (version 1)
 
 ```json
-[
-  {
-    "id": "<GUID>",
-    "type": "connectionString",
-    "name": "<NAME>",
-    "connectionString": "<CONNECTION_STRING>",
-    "target": "serviceBus"
-  }
-]
+{
+  "version": 1,
+  "workspaces": [
+    {
+      "id": "<GUID>",
+      "name": "Production",
+      "connections": [
+        {
+          "id": "<GUID>",
+          "type": "systemAssignedManagedIdentity",
+          "name": "My Service Bus",
+          "fullyQualifiedNamespace": "<NAMESPACE>",
+          "target": "serviceBus"
+        }
+      ]
+    }
+  ]
+}
+```
+
+> [!NOTE]
+> All `id` fields must be valid UUIDs, unique across the entire file (workspace IDs must be unique among workspaces; connection IDs must be unique across **all** workspaces).
+
+> [!NOTE]
+> **Legacy format**: if your `sbb-connections.json` is still a flat array (the old format), the backend will automatically wrap it in a single "Default" workspace and log a deprecation warning. Migrate by wrapping your connections in the versioned format above.
+
+#### Connection types
+
+**Service Bus — system-assigned managed identity** *(recommended)*
+```json
+{
+  "id": "<GUID>",
+  "type": "systemAssignedManagedIdentity",
+  "name": "<NAME>",
+  "fullyQualifiedNamespace": "<NAMESPACE>",
+  "target": "serviceBus"
+}
+```
+
+**Service Bus — user-assigned managed identity** *(recommended)*
+```json
+{
+  "id": "<GUID>",
+  "type": "userAssignedManagedIdentity",
+  "name": "<NAME>",
+  "fullyQualifiedNamespace": "<NAMESPACE>",
+  "clientId": "<CLIENT_ID>",
+  "target": "serviceBus"
+}
+```
+
+**Service Bus — connection string**
+```json
+{
+  "id": "<GUID>",
+  "type": "connectionString",
+  "name": "<NAME>",
+  "connectionString": "<CONNECTION_STRING>",
+  "target": "serviceBus"
+}
 ```
 > [!IMPORTANT]
-> While possible, using connection strings in the web version of Service Bus Browser is strongly discouraged due to security concerns. This primarily applies when running the container beyond your local machine; in those scenarios, a secretless option such as managed identities is strongly recommended.
+> Using connection strings in the web version is strongly discouraged for deployments beyond your local machine. Prefer a secretless option such as managed identities.
 
-Service Bus - Service principal client secret:
+**Service Bus — service principal client secret**
 ```json
-[
-  {
-    "id": "<GUID>",
-    "type": "ServicePrincipalClientSecret",
-    "name": "<NAME>",
-    "fullyQualifiedNamespace": "<NAMESPACE>",
-    "clientId": "<CLIENT_ID>",
-    "clientSecret": "<CLIENT_SECRET>",
-    "tenantId": "<TENANT_ID>",
-    "authority": "<AUTHORITY>",
-    "target": "serviceBus"
-  }
-]
+{
+  "id": "<GUID>",
+  "type": "ServicePrincipalClientSecret",
+  "name": "<NAME>",
+  "fullyQualifiedNamespace": "<NAMESPACE>",
+  "clientId": "<CLIENT_ID>",
+  "clientSecret": "<CLIENT_SECRET>",
+  "tenantId": "<TENANT_ID>",
+  "authority": "<AUTHORITY>",
+  "target": "serviceBus"
+}
 ```
 > [!IMPORTANT]
-> While possible, using service principal secrets in the web version of Service Bus Browser is strongly discouraged due to security concerns. This primarily applies when running the container beyond your local machine; in those scenarios, a secretless option such as managed identities is strongly recommended.
+> Using service principal secrets in the web version is strongly discouraged for deployments beyond your local machine. Prefer a secretless option such as managed identities.
 
-Service Bus - System assigned managed identity:
+**RabbitMQ**
 ```json
-[
-  {
-    "id": "<GUID>",
-    "type": "systemAssignedManagedIdentity",
-    "name": "<NAME>",
-    "fullyQualifiedNamespace": "<NAMESPACE>",
-    "target": "serviceBus"
-  }
-]
+{
+  "id": "<GUID>",
+  "type": "connectionString",
+  "name": "<NAME>",
+  "host": "<HOST>",
+  "managementPort": 15672,
+  "amqpPort": 5672,
+  "vhost": "/",
+  "userName": "<USERNAME>",
+  "password": "<PASSWORD>",
+  "target": "rabbitmq"
+}
 ```
 
-Service Bus - User assigned managed identity:
-```json
-[
-  {
-    "id": "<GUID>",
-    "type": "userAssignedManagedIdentity",
-    "name": "<NAME>",
-    "fullyQualifiedNamespace": "<NAMESPACE>",
-    "clientId": "<CLIENT_ID>",
-    "target": "serviceBus"
-  }
-]
-```
+## Run the application
 
-Service Bus - RabbitMQ connection:
-```json
-[
-  {
-    "id": "<GUID>",
-    "type": "connectionString",
-    "name": "<NAME>",
-    "host": "<HOST>",
-    "managementPort": 15672,
-    "amqpPort": 5672,
-    "vhost": "/",
-    "userName": "<USERNAME>",
-    "password": "<PASSWORD>",
-    "target": "rabbitmq"
-  }
-]
-```
-
-## run the application
-To run the web version, mount both configuration files into the container:
+Mount both configuration files into the container:
 ```bash
-docker run -p 8080:80\
-  --mount type=bind,src=./openid-config.json,dst=/app/openid-config.json\
-  --mount type=bind,src=./sbb-connections.json,dst=/app/sbb-connections.json\
+docker run -p 8080:80 \
+  --mount type=bind,src=./openid-config.json,dst=/app/openid-config.json \
+  --mount type=bind,src=./sbb-connections.json,dst=/app/sbb-connections.json \
   ghcr.io/mligtenberg/servicebusbrowser:main
 ```
+
+The active workspace the user last selected is stored in browser `localStorage` and restored on the next visit. If the stored workspace no longer exists in the config (e.g. it was removed by the operator), the first workspace in the array becomes active automatically.

--- a/docs/web-config-format.md
+++ b/docs/web-config-format.md
@@ -1,0 +1,80 @@
+# Web Backend Config Format
+
+The web backend reads a single `sbb-connections.json` file from its working directory. This file defines all workspaces and their connections.
+
+## Versioned format (v1)
+
+```json
+{
+  "version": 1,
+  "workspaces": [
+    {
+      "id": "550e8400-e29b-41d4-a716-446655440000",
+      "name": "Production",
+      "connections": [
+        {
+          "id": "6ba7b810-9dad-11d1-80b4-00c04fd430c8",
+          "name": "Primary Namespace",
+          "type": "servicebus",
+          "target": "servicebus",
+          "connectionString": "Endpoint=sb://..."
+        }
+      ]
+    },
+    {
+      "id": "6ba7b811-9dad-11d1-80b4-00c04fd430c8",
+      "name": "Staging",
+      "connections": []
+    }
+  ]
+}
+```
+
+### Validation rules
+
+The backend validates the config on startup and refuses to serve if any rule is violated:
+
+- Every workspace must have a valid UUID `id` and a non-empty `name`.
+- Workspace `id` values must be unique within the file.
+- Connection `id` values must be unique **across all workspaces** in the file (not just within one workspace).
+- `version` must be `1`.
+
+Unknown extra fields on workspace objects are warned about and ignored (forward-compatible).
+
+## Legacy format (auto-migration)
+
+If the config file is a flat JSON array (the original format before workspaces were introduced), the backend auto-wraps all connections into a single synthetic **"Default"** workspace at read time and emits a deprecation warning in the log:
+
+```json
+[
+  { "id": "...", "name": "My Connection", "type": "servicebus", ... }
+]
+```
+
+Migrate by wrapping your connections:
+
+```json
+{
+  "version": 1,
+  "workspaces": [
+    {
+      "id": "<new-uuid>",
+      "name": "Default",
+      "connections": [ ... your existing connections ... ]
+    }
+  ]
+}
+```
+
+## Active workspace
+
+The web frontend persists the last-selected workspace id in browser `localStorage` under the key `sbb-active-workspace-id`. On boot, the stored id is matched against the workspace list from the backend:
+
+- If it matches a workspace, that workspace becomes active.
+- If it is absent or no longer present in the config (e.g. it was removed by the operator), the **first** workspace in the array becomes active.
+
+The active workspace is synced to the backend on boot and on every switch so the backend can filter connections accordingly.
+
+## Workspace management
+
+The web frontend **does not** support creating, renaming, or deleting workspaces. These operations are performed by the operator by editing `sbb-connections.json` and restarting the backend.

--- a/libs/api-clients/angular-bindings/src/web-backend-api.ts
+++ b/libs/api-clients/angular-bindings/src/web-backend-api.ts
@@ -1,21 +1,17 @@
 import { HttpClient } from '@angular/common/http';
 import { firstValueFrom, lastValueFrom, map } from 'rxjs';
 import { BackendApi } from '@service-bus-browser/service-bus-frontend-clients';
-import { Workspace, UUID } from '@service-bus-browser/shared-contracts';
 import { BSON } from 'bson';
 
 /**
  * Single backend handler for the web variant.
  *
- * - management / serviceBusManagement / messages requests are POSTed to the
- *   web backend, which executes them via the shared Server instance.
- * - workspaces requests are handled locally against localStorage, because the
- *   web variant has no server-side workspace registry. The shape mirrors the
- *   desktop variant's sbb-workspaces.json so callers stay platform-agnostic.
+ * All four request categories (management, serviceBusManagement, messages,
+ * workspaces) are POSTed to the web backend. The workspaces endpoint exposes
+ * the operator-configured workspace list; workspace mutations (create/rename/
+ * delete) are not supported on web — the operator edits the config file.
  */
 export class WebBackendApi implements BackendApi {
-  private static readonly WORKSPACES_STORAGE_KEY = 'sbb-workspaces';
-
   constructor(
     private readonly baseUrl: string,
     private readonly httpClient: HttpClient,
@@ -79,94 +75,18 @@ export class WebBackendApi implements BackendApi {
     requestType: string,
     request: unknown,
   ): Promise<unknown> {
-    switch (requestType) {
-      case 'listWorkspaces':
-        return this.listWorkspaces();
-      case 'createWorkspace':
-        return this.createWorkspace((request as { name: string }).name);
-      case 'setActiveWorkspace':
-        // On web the active workspace is tracked via WorkspaceService/localStorage;
-        // no separate persistence step is needed here.
-        return;
-      case 'renameWorkspace':
-        return this.renameWorkspace(
-          (request as { id: UUID; name: string }).id,
-          (request as { id: UUID; name: string }).name,
-        );
-      case 'deleteWorkspace':
-        return this.deleteWorkspaceFromStorage((request as { id: UUID }).id);
-      case 'countConnectionsByWorkspace':
-        // Web has no server-side connection tracking per workspace.
-        return 0;
-      default:
-        throw new Error(`Unknown workspaces request: ${requestType}`);
-    }
-  }
-
-  private listWorkspaces(): Workspace[] {
-    const stored = localStorage.getItem(WebBackendApi.WORKSPACES_STORAGE_KEY);
-    if (stored) {
-      return JSON.parse(stored) as Workspace[];
-    }
-
-    // First boot on web — seed a Default workspace, mirroring desktop's
-    // migration step that writes a single-entry registry.
-    const workspaces: Workspace[] = [
-      {
-        id: crypto.randomUUID() as UUID,
-        name: 'Default',
-        createdAt: new Date().toISOString(),
-      },
-    ];
-    localStorage.setItem(
-      WebBackendApi.WORKSPACES_STORAGE_KEY,
-      JSON.stringify(workspaces),
+    return await firstValueFrom(
+      this.httpClient
+        .post(
+          `${this.baseUrl}workspaces/command`,
+          { requestType, body: request },
+          {
+            headers: { 'Content-Type': 'application/json' },
+            responseType: 'blob',
+          },
+        )
+        .pipe(map((response) => this.decodeResponse(response))),
     );
-    return workspaces;
-  }
-
-  private renameWorkspace(id: UUID, name: string): void {
-    name = name.trim();
-    if (name === '') throw new Error('Workspace name cannot be empty');
-    const workspaces = this.listWorkspaces().map((w) =>
-      w.id === id ? { ...w, name } : w,
-    );
-    localStorage.setItem(
-      WebBackendApi.WORKSPACES_STORAGE_KEY,
-      JSON.stringify(workspaces),
-    );
-  }
-
-  private deleteWorkspaceFromStorage(id: UUID): void {
-    const workspaces = this.listWorkspaces().filter((w) => w.id !== id);
-    localStorage.setItem(
-      WebBackendApi.WORKSPACES_STORAGE_KEY,
-      JSON.stringify(workspaces),
-    );
-  }
-
-  private createWorkspace(name: string): Workspace {
-    name = name.trim();
-    if (name === '') {
-      throw new Error('Workspace name cannot be empty');
-    }
-    const workspaces = this.listWorkspaces();
-    const duplicate = workspaces.some(
-      (w) => w.name.toLowerCase() === name.toLowerCase(),
-    );
-    if (duplicate) {
-      throw new Error(`A workspace named "${name}" already exists`);
-    }
-    const workspace: Workspace = {
-      id: crypto.randomUUID() as UUID,
-      name,
-      createdAt: new Date().toISOString(),
-    };
-    localStorage.setItem(
-      WebBackendApi.WORKSPACES_STORAGE_KEY,
-      JSON.stringify([...workspaces, workspace]),
-    );
-    return workspace;
   }
 
   private async decodeResponse(response: Blob): Promise<any> {


### PR DESCRIPTION
## Summary

Implements [issue #146](https://github.com/mligtenberg/ServicebusBrowser/issues/146): the web variant now sources workspaces and their connections from an operator-edited config file instead of a flat connection list, and the workspace switcher is rendered in the web frontend (read-only — no create/rename/delete).

## What changed

### Web backend

- **New versioned config format** (`sbb-connections.json`):
  ```json
  {
    "version": 1,
    "workspaces": [
      { "id": "<uuid>", "name": "Production", "connections": [ ... ] }
    ]
  }
  ```
- **`web-config-loader.ts`** — parses the new format; auto-wraps legacy flat-array and version-less configs into a single "Default" workspace with a deprecation warning; validates UUID `id` + non-empty `name` on every workspace, globally-unique workspace IDs, globally-unique connection IDs across the file; fails fast on violation; unknown extra fields are warned and ignored.
- **`ConfigFileWorkspaceStore`** — read-only `WorkspaceStore` implementation; `setActiveWorkspaceId` updates an in-memory holder shared with the connection store.
- **`ReadonlyConfigFileConnectionStorage`** — now filters `listConnections`/`getConnection` to the active workspace only.
- **`/api/workspaces/command`** endpoint added, backed by `WorkspacesServer`.

### Web frontend

- **`WebBackendApi`** — all workspace operations now POST to `/api/workspaces/command`; localStorage workspace management removed.
- **Read-only `WorkspaceSwitcherComponent`** added to the web app: lists workspaces, supports click-to-switch with in-flight confirmation dialog; no create/rename/delete actions (operator manages workspaces via config file).
- Active workspace ID persisted in `localStorage` (`sbb-active-workspace-id`); falls back to first workspace if stored ID is absent or no longer in config.
- `WorkspaceSwitchService` added to web frontend app (same tear-down/rehydrate path as desktop: cancels tasks, switches messages-db, reloads topology).

### Auth-ordering fix

- Workspace init was in `APP_INITIALIZER`, which runs concurrently with `withAppInitializerAuthCheck()` — the HTTP call fired before the OIDC token was available, causing a 401 and a blank page.
- Moved workspace loading into `MainApp.ngOnInit()`, which only runs after `AutoLoginPartialRoutesGuard` confirms authentication. The main UI is gated on a `workspacesInitialized` signal.

### Documentation

- `docs/web-config-format.md` — describes the config shape, validation rules, legacy migration path, and active-workspace persistence.

## Reviewer notes

- The web backend is intentionally **read-only**: create/rename/delete workspace operations throw with a clear message directing the operator to edit the config file.
- `setActiveWorkspace` is the one mutable backend operation — it updates an in-memory `activeWorkspaceHolder` so the `Server`'s connection store knows which workspace's connections to expose. This is reset on every backend restart; the frontend re-syncs on each page load.
- The desktop app (`servicebus-browser-frontend`) is unaffected; only the `workspace-switch.service.ts` import path was cleaned up (it now re-exports from the original location unchanged).

## Blocked by

Closes #146 (blocked by #142).