### PR TITLE
feat(messages): show prefilled filter popover on 'Add filter for X'

### DIFF
--- a/libs/messages/flow/src/lib/messages-page/messages-page.component.html
+++ b/libs/messages/flow/src/lib/messages-page/messages-page.component.html
@@ -121,3 +121,41 @@
   [knownDeliveryAnnotations]="knownDeliveryAnnotations()"
   [knownMessageAnnotations]="knownMessageAnnotations()"
 ></lib-message-filter-editor>
+
+<p-popover
+  #filterPopover
+  appendTo="body"
+  (onHide)="onFilterPopoverHide()"
+>
+  <div class="filter-popover-content">
+    <h3 class="filter-popover-title">Add {{ filterSectionLabel() }} Filter</h3>
+    @if (filterPopoverVisible()) {
+      @if (currentFilterSection() === 'applicationProperties') {
+        <lib-application-property-form
+          [(value)]="currentFilterDraft"
+          [availableApplicationProperties]="filterFormProperties()"
+          [required]="true"
+        />
+      } @else {
+        <lib-system-property-form
+          [(value)]="currentFilterDraft"
+          [availableSystemProperties]="filterFormProperties()"
+          [required]="true"
+        />
+      }
+    }
+    <div class="filter-popover-footer">
+      <p-button
+        label="Cancel"
+        severity="secondary"
+        icon="pi pi-times"
+        (click)="cancelFilterPopover()"
+      ></p-button>
+      <p-button
+        label="Add Filter"
+        icon="pi pi-filter"
+        (click)="saveFilterPopover()"
+      ></p-button>
+    </div>
+  </div>
+</p-popover>

--- a/libs/messages/flow/src/lib/messages-page/messages-page.component.html
+++ b/libs/messages/flow/src/lib/messages-page/messages-page.component.html
@@ -26,6 +26,7 @@
       [(selection)]="selection"
       (selectionChange)="onSelectionChange($event)"
       [isLoading]="isLoading()"
+      [bodyContextActions]="bodyContextActions"
       #messagesViewer
     >
       <ng-template #messagesHeaderStatus>
@@ -130,7 +131,12 @@
   <div class="filter-popover-content">
     <h3 class="filter-popover-title">Add {{ filterSectionLabel() }} Filter</h3>
     @if (filterPopoverVisible()) {
-      @if (currentFilterSection() === 'applicationProperties') {
+      @if (currentFilterSection() === 'body') {
+        <lib-body-property-form
+          [(value)]="currentBodyFilterDraft"
+          [required]="true"
+        />
+      } @else if (currentFilterSection() === 'applicationProperties') {
         <lib-application-property-form
           [(value)]="currentFilterDraft"
           [availableApplicationProperties]="filterFormProperties()"

--- a/libs/messages/flow/src/lib/messages-page/messages-page.component.scss
+++ b/libs/messages/flow/src/lib/messages-page/messages-page.component.scss
@@ -52,6 +52,27 @@
   height: 100cqh;
 }
 
+.filter-popover-content {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  min-width: 360px;
+
+  .filter-popover-title {
+    margin: 0;
+    font-size: 1rem;
+    font-weight: 600;
+  }
+
+  .filter-popover-footer {
+    display: flex;
+    justify-content: space-between;
+    gap: 0.5rem;
+    padding-top: 0.5rem;
+    border-top: 1px solid var(--p-content-border-color);
+  }
+}
+
 lib-messages-viewer {
   flex: 1;
 }

--- a/libs/messages/flow/src/lib/messages-page/messages-page.component.ts
+++ b/libs/messages/flow/src/lib/messages-page/messages-page.component.ts
@@ -34,7 +34,7 @@ import {
   toSignal,
 } from '@angular/core/rxjs-interop';
 import { MessagePage } from '@service-bus-browser/messages-contracts';
-import { MessageFilter, PropertyFilter } from '@service-bus-browser/filtering';
+import { BodyFilter, MessageFilter, PropertyFilter } from '@service-bus-browser/filtering';
 import { TableLazyLoadEvent, TableModule } from 'primeng/table';
 import { FormsModule } from '@angular/forms';
 import { Dialog } from 'primeng/dialog';
@@ -55,6 +55,8 @@ import { Tooltip } from 'primeng/tooltip';
 import { Popover } from 'primeng/popover';
 import { SystemPropertyForm } from '../message-filter-editor/system-property-form/system-property-form';
 import { ApplicationPropertyForm } from '../message-filter-editor/application-property-form/application-property-form';
+import { BodyPropertyForm } from '../message-filter-editor/body-property-form/body-property-form';
+import { EditorContextAction } from '@service-bus-browser/shared-components';
 import { hasActiveFilters as hasActiveFilterFunc } from '@service-bus-browser/filtering';
 import { Actions } from '@ngrx/effects';
 import { getMessagesRepository } from '@service-bus-browser/messages-db';
@@ -84,6 +86,7 @@ import MessagesViewer from '../messages-viewer/messages-viewer';
     Popover,
     SystemPropertyForm,
     ApplicationPropertyForm,
+    BodyPropertyForm,
   ],
   templateUrl: './messages-page.component.html',
   styleUrl: './messages-page.component.scss',
@@ -300,6 +303,7 @@ export class MessagesPageComponent {
     | 'deliveryAnnotations'
     | 'messageAnnotations'
     | 'applicationProperties'
+    | 'body'
   >('properties');
   currentFilterDraft = signal<PropertyFilter>({
     isActive: true,
@@ -308,7 +312,20 @@ export class MessagesPageComponent {
     filterType: 'equals',
     value: '',
   });
+  currentBodyFilterDraft = signal<BodyFilter>({
+    isActive: true,
+    filterType: 'contains',
+    value: '',
+  });
   filterPopoverVisible = signal(false);
+
+  protected bodyContextActions: EditorContextAction[] = [
+    {
+      id: 'add-body-contains-filter',
+      label: 'Add body contains filter',
+      run: (selectedText) => this.openDraftBodyFilterPopover(selectedText),
+    },
+  ];
 
   filterFormProperties = computed(() => {
     const section = this.currentFilterSection();
@@ -334,6 +351,7 @@ export class MessagesPageComponent {
       case 'deliveryAnnotations': return 'Delivery Annotation';
       case 'messageAnnotations': return 'Message Annotation';
       case 'applicationProperties': return 'Application Property';
+      case 'body': return 'Body';
     }
   });
 
@@ -738,6 +756,17 @@ export class MessagesPageComponent {
     this.openDraftFilterPopover(key, value, 'applicationProperties');
   }
 
+  openDraftBodyFilterPopover(selectedText: string): void {
+    this.currentFilterSection.set('body');
+    this.currentBodyFilterDraft.set({
+      isActive: true,
+      filterType: 'contains',
+      value: selectedText,
+    });
+    this.filterPopoverVisible.set(true);
+    this.showDraftFilterPopover();
+  }
+
   private openDraftFilterPopover(
     key: string,
     value: string | number | boolean | Date,
@@ -780,14 +809,20 @@ export class MessagesPageComponent {
   }
 
   saveFilterPopover(): void {
-    const draft = this.currentFilterDraft();
     const section = this.currentFilterSection();
     const currentFilter = this.messageFilter();
 
-    this.onFiltersUpdated({
-      ...currentFilter,
-      [section]: [...currentFilter[section], draft],
-    });
+    if (section === 'body') {
+      this.onFiltersUpdated({
+        ...currentFilter,
+        body: [...currentFilter.body, this.currentBodyFilterDraft()],
+      });
+    } else {
+      this.onFiltersUpdated({
+        ...currentFilter,
+        [section]: [...currentFilter[section], this.currentFilterDraft()],
+      });
+    }
 
     this.filterPopover()?.hide();
   }

--- a/libs/messages/flow/src/lib/messages-page/messages-page.component.ts
+++ b/libs/messages/flow/src/lib/messages-page/messages-page.component.ts
@@ -542,9 +542,10 @@ export class MessagesPageComponent {
       this.lastContextMenuPosition = { x: event.clientX, y: event.clientY };
     };
     this.document.addEventListener('contextmenu', onContextMenu, true);
-    this.destroyRef.onDestroy(() =>
-      this.document.removeEventListener('contextmenu', onContextMenu, true),
-    );
+    this.destroyRef.onDestroy(() => {
+      this.document.removeEventListener('contextmenu', onContextMenu, true);
+      this.removeFilterPopoverAnchor();
+    });
 
     this.activatedRoute.params
       .pipe(
@@ -785,6 +786,7 @@ export class MessagesPageComponent {
   }
 
   private showDraftFilterPopover(): void {
+    this.removeFilterPopoverAnchor();
     const position = this.lastContextMenuPosition;
     if (!position) {
       this.filterPopover()?.show(new Event('click'));

--- a/libs/messages/flow/src/lib/messages-page/messages-page.component.ts
+++ b/libs/messages/flow/src/lib/messages-page/messages-page.component.ts
@@ -2,13 +2,15 @@ import {
   ApplicationRef,
   Component,
   computed,
+  DestroyRef,
   inject,
   input,
   linkedSignal,
   model,
   signal,
+  viewChild,
 } from '@angular/core';
-import { CommonModule } from '@angular/common';
+import { CommonModule, DOCUMENT } from '@angular/common';
 import { Store } from '@ngrx/store';
 import {
   messagePagesActions,
@@ -50,6 +52,9 @@ import {
 import { Menu } from 'primeng/menu';
 import { MessageFilterEditorComponent } from '../message-filter-editor/message-filter-editor.component';
 import { Tooltip } from 'primeng/tooltip';
+import { Popover } from 'primeng/popover';
+import { SystemPropertyForm } from '../message-filter-editor/system-property-form/system-property-form';
+import { ApplicationPropertyForm } from '../message-filter-editor/application-property-form/application-property-form';
 import { hasActiveFilters as hasActiveFilterFunc } from '@service-bus-browser/filtering';
 import { Actions } from '@ngrx/effects';
 import { getMessagesRepository } from '@service-bus-browser/messages-db';
@@ -76,6 +81,9 @@ import MessagesViewer from '../messages-viewer/messages-viewer';
     MessageFilterEditorComponent,
     Tooltip,
     MessagesViewer,
+    Popover,
+    SystemPropertyForm,
+    ApplicationPropertyForm,
   ],
   templateUrl: './messages-page.component.html',
   styleUrl: './messages-page.component.scss',
@@ -285,6 +293,55 @@ export class MessagesPageComponent {
     { key: string; value: unknown } | undefined
   >(undefined);
 
+  filterPopover = viewChild<Popover>('filterPopover');
+  currentFilterSection = signal<
+    | 'headers'
+    | 'properties'
+    | 'deliveryAnnotations'
+    | 'messageAnnotations'
+    | 'applicationProperties'
+  >('properties');
+  currentFilterDraft = signal<PropertyFilter>({
+    isActive: true,
+    fieldName: '',
+    fieldType: 'string',
+    filterType: 'equals',
+    value: '',
+  });
+  filterPopoverVisible = signal(false);
+
+  filterFormProperties = computed(() => {
+    const section = this.currentFilterSection();
+    const draft = this.currentFilterDraft();
+    let known: { label: string; type: string }[] = [];
+    switch (section) {
+      case 'headers': known = [...this.knownHeaders()]; break;
+      case 'properties': known = [...this.knownProperties()]; break;
+      case 'deliveryAnnotations': known = [...this.knownDeliveryAnnotations()]; break;
+      case 'messageAnnotations': known = [...this.knownMessageAnnotations()]; break;
+      case 'applicationProperties': known = [...this.knownApplicationProperties()]; break;
+    }
+    if (draft.fieldName && !known.find((k) => k.label === draft.fieldName)) {
+      known = [{ label: draft.fieldName, type: draft.fieldType }, ...known];
+    }
+    return known;
+  });
+
+  filterSectionLabel = computed(() => {
+    switch (this.currentFilterSection()) {
+      case 'headers': return 'Header';
+      case 'properties': return 'Property';
+      case 'deliveryAnnotations': return 'Delivery Annotation';
+      case 'messageAnnotations': return 'Message Annotation';
+      case 'applicationProperties': return 'Application Property';
+    }
+  });
+
+  private document = inject(DOCUMENT);
+  private destroyRef = inject(DestroyRef);
+  private lastContextMenuPosition: { x: number; y: number } | undefined;
+  private filterPopoverAnchorEl: HTMLElement | undefined;
+
   headersContextMenu = computed(() => {
     let selection = this.headersContextMenuSelection();
     if (!selection) {
@@ -463,6 +520,14 @@ export class MessagesPageComponent {
   });
 
   constructor() {
+    const onContextMenu = (event: MouseEvent) => {
+      this.lastContextMenuPosition = { x: event.clientX, y: event.clientY };
+    };
+    this.document.addEventListener('contextmenu', onContextMenu, true);
+    this.destroyRef.onDestroy(() =>
+      this.document.removeEventListener('contextmenu', onContextMenu, true),
+    );
+
     this.activatedRoute.params
       .pipe(
         map((params) => params['pageId']),
@@ -653,128 +718,87 @@ export class MessagesPageComponent {
     );
   }
 
-  protected filterOnProperty(
-    key: string,
-    value: string | number | boolean | Date,
-  ) {
-    this.displayFilterEditor.set(false);
-    const fieldType = this.toFilterPropertyType(key, value);
-
-    let currentFilter = this.messageFilter();
-    currentFilter = {
-      ...currentFilter,
-      properties: [
-        ...currentFilter.properties,
-        {
-          fieldName: key,
-          filterType: 'equals',
-          value: value,
-          fieldType: fieldType,
-          isActive: true,
-        } as PropertyFilter,
-      ],
-    };
-
-    this.onFiltersUpdated(currentFilter);
+  protected filterOnProperty(key: string, value: string | number | boolean | Date) {
+    this.openDraftFilterPopover(key, value, 'properties');
   }
 
-  protected filterOnHeader(
-    key: string,
-    value: string | number | boolean | Date,
-  ) {
-    this.displayFilterEditor.set(false);
-    const fieldType = this.toFilterPropertyType(key, value);
-
-    let currentFilter = this.messageFilter();
-    currentFilter = {
-      ...currentFilter,
-      headers: [
-        ...currentFilter.headers,
-        {
-          fieldName: key,
-          filterType: 'equals',
-          value: value,
-          fieldType: fieldType,
-          isActive: true,
-        } as PropertyFilter,
-      ],
-    };
-
-    this.onFiltersUpdated(currentFilter);
+  protected filterOnHeader(key: string, value: string | number | boolean | Date) {
+    this.openDraftFilterPopover(key, value, 'headers');
   }
 
-  protected filterOnDeliveryAnnotation(
-    key: string,
-    value: string | number | boolean | Date,
-  ) {
-    this.displayFilterEditor.set(false);
-    const fieldType = this.toFilterPropertyType(key, value);
-
-    let currentFilter = this.messageFilter();
-    currentFilter = {
-      ...currentFilter,
-      deliveryAnnotations: [
-        ...currentFilter.deliveryAnnotations,
-        {
-          fieldName: key,
-          filterType: 'equals',
-          value: value,
-          fieldType: fieldType,
-          isActive: true,
-        } as PropertyFilter,
-      ],
-    };
-
-    this.onFiltersUpdated(currentFilter);
+  protected filterOnDeliveryAnnotation(key: string, value: string | number | boolean | Date) {
+    this.openDraftFilterPopover(key, value, 'deliveryAnnotations');
   }
 
-  protected filterOnMessageAnnotation(
-    key: string,
-    value: string | number | boolean | Date,
-  ) {
-    this.displayFilterEditor.set(false);
-    const fieldType = this.toFilterPropertyType(key, value);
-
-    let currentFilter = this.messageFilter();
-    currentFilter = {
-      ...currentFilter,
-      messageAnnotations: [
-        ...currentFilter.messageAnnotations,
-        {
-          fieldName: key,
-          filterType: 'equals',
-          value: value,
-          fieldType: fieldType,
-          isActive: true,
-        } as PropertyFilter,
-      ],
-    };
-
-    this.onFiltersUpdated(currentFilter);
+  protected filterOnMessageAnnotation(key: string, value: string | number | boolean | Date) {
+    this.openDraftFilterPopover(key, value, 'messageAnnotations');
   }
 
-  protected filterOnApplicationProperty(
+  protected filterOnApplicationProperty(key: string, value: string | number | boolean | Date) {
+    this.openDraftFilterPopover(key, value, 'applicationProperties');
+  }
+
+  private openDraftFilterPopover(
     key: string,
     value: string | number | boolean | Date,
+    section: 'headers' | 'properties' | 'deliveryAnnotations' | 'messageAnnotations' | 'applicationProperties',
   ) {
-    this.displayFilterEditor.set(false);
+    this.currentFilterSection.set(section);
+    this.currentFilterDraft.set({
+      fieldName: key,
+      filterType: 'equals',
+      value: value,
+      fieldType: this.toFilterPropertyType(key, value),
+      isActive: true,
+    } as PropertyFilter);
+    this.filterPopoverVisible.set(true);
+    this.showDraftFilterPopover();
+  }
 
-    let currentFilter = this.messageFilter();
-    currentFilter = {
+  private showDraftFilterPopover(): void {
+    const position = this.lastContextMenuPosition;
+    if (!position) {
+      this.filterPopover()?.show(new Event('click'));
+      return;
+    }
+
+    const anchor = this.document.createElement('div');
+    anchor.style.position = 'fixed';
+    anchor.style.left = `${position.x}px`;
+    anchor.style.top = `${position.y}px`;
+    anchor.style.width = '1px';
+    anchor.style.height = '1px';
+    anchor.style.pointerEvents = 'none';
+    this.document.body.appendChild(anchor);
+    this.filterPopoverAnchorEl = anchor;
+    this.filterPopover()?.show(new Event('click'), anchor);
+  }
+
+  private removeFilterPopoverAnchor(): void {
+    this.filterPopoverAnchorEl?.remove();
+    this.filterPopoverAnchorEl = undefined;
+  }
+
+  saveFilterPopover(): void {
+    const draft = this.currentFilterDraft();
+    const section = this.currentFilterSection();
+    const currentFilter = this.messageFilter();
+
+    this.onFiltersUpdated({
       ...currentFilter,
-      applicationProperties: [
-        ...currentFilter.applicationProperties,
-        {
-          fieldName: key,
-          filterType: 'equals',
-          value: value,
-          fieldType: this.toFilterPropertyType(key, value),
-          isActive: true,
-        } as PropertyFilter,
-      ],
-    };
+      [section]: [...currentFilter[section], draft],
+    });
 
-    this.onFiltersUpdated(currentFilter);
+    this.filterPopover()?.hide();
+  }
+
+  cancelFilterPopover(): void {
+    this.filterPopover()?.hide();
+  }
+
+  onFilterPopoverHide(): void {
+    this.removeFilterPopoverAnchor();
+    this.filterPopoverVisible.set(false);
   }
 
   private toFilterPropertyType(


### PR DESCRIPTION
## Summary

- Right-clicking a property row and choosing **Add filter for X** in the message viewer now opens a `p-popover` anchored at the right-click position instead of immediately committing the filter.
- The popover is prefilled with the property's key, auto-detected type, `equals` operator, and the property value — the user can adjust any field before confirming.
- Uses `SystemPropertyForm` for headers / properties / delivery annotations / message annotations, and `ApplicationPropertyForm` for application properties.
- Follows the same anchor + `p-popover` pattern introduced for the batch resend **Add action** popover (captured right-click coordinates → 1px fixed anchor element → `popover.show()`).

## What changed

| File | Change |
|---|---|
| `messages-page.component.ts` | Replaced the five `filterOn*` methods with an `openDraftFilterPopover` flow; added `viewChild<Popover>`, `currentFilterDraft` / `currentFilterSection` signals, `filterFormProperties` and `filterSectionLabel` computed, `lastContextMenuPosition` tracking, and save/cancel/hide handlers |
| `messages-page.component.html` | Added `<p-popover #filterPopover>` with conditional `SystemPropertyForm` / `ApplicationPropertyForm` and Save/Cancel buttons |
| `messages-page.component.scss` | Added `.filter-popover-content` layout styles matching the batch resend popover |

## Test plan

- [ ] Right-click a header property → popover appears prefilled with the header key, type, and value
- [ ] Right-click a message property → correct `SystemPropertyForm` shown prefilled
- [ ] Right-click a delivery annotation or message annotation → correct form shown
- [ ] Right-click an application property → `ApplicationPropertyForm` shown prefilled
- [ ] Adjust the filter type / value in the popover, click **Add Filter** → filter is applied correctly
- [ ] Click **Cancel** → no filter is added
- [ ] Verify popover is anchored near the right-click position
- [ ] Open the full filter editor independently — still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a filter popover interface to the messages page for configuring message filters. Users can now open a dedicated filter panel to select filter types and save their selections through a user-friendly popover dialog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->