### PR TITLE
feat(topology): tag + free-text search for the topology navigator

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -58,7 +58,9 @@ sidebar tree that renders it.
 ## Search Tag
 
 An exact, type-scoped filter token in the Topology Navigator search, rendered as
-a chip and serialized as `[type: value]`. A Tag binds one value to one entity
+a chip showing `type: value`. (The `[type: value]` bracket form is only a
+notation for describing tags in writing — it is never shown in the UI.) A Tag
+binds one value to one entity
 node type (e.g. `connection`, `exchange`) and can only be created by selecting a
 suggestion — never typed raw. Tags of different types combine by narrowing down
 the topology hierarchy (logical AND); at most one Tag per type exists at a time.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -45,3 +45,27 @@ A tab in the message-viewing UI representing one retrieved set of messages from
 a queue/topic/subscription. Each Message Page has its own SQLite store
 (OPFS-backed), row selection state, and column ordering. Message Pages are
 owned by a single Workspace.
+
+## Topology
+
+The live tree of entities reachable through the active Workspace's
+**Connections**, derived on demand from each broker (never persisted). Its nodes
+are typed: structural nodes (`connection`, the vhost, and grouping folders such
+as "Queues"/"Topics") and addressable entity nodes (queue, topic, subscription,
+rule, exchange, event hub, consumer group). The **Topology Navigator** is the
+sidebar tree that renders it.
+
+## Search Tag
+
+An exact, type-scoped filter token in the Topology Navigator search, rendered as
+a chip and serialized as `[type: value]`. A Tag binds one value to one entity
+node type (e.g. `connection`, `exchange`) and can only be created by selecting a
+suggestion — never typed raw. Tags of different types combine by narrowing down
+the topology hierarchy (logical AND); at most one Tag per type exists at a time.
+_Avoid_: filter, facet, token (in user-facing language, prefer "tag").
+
+## Free Text
+
+The untagged remainder of a Topology Navigator search query: a case-insensitive
+substring matched against entity node names, applied within the scope the Tags
+establish. The fuzzy counterpart to the exact **Search Tag**.

--- a/docs/adr/0004-topology-search-chip-model.md
+++ b/docs/adr/0004-topology-search-chip-model.md
@@ -1,12 +1,14 @@
 # Topology Navigator search uses an autosuggest-only chip model
 
 The Topology Navigator search is a chip/token input rather than a plain text
-filter. **Tags** — exact, type-scoped filters serialized as `[type: value]` —
-can only be created by selecting an autosuggest suggestion, are rendered as
-atomic non-editable, non-copyable chips, and combine by narrowing down the
-topology hierarchy (always AND, at most one chip per node type). Free text
-typed alongside the chips is a case-insensitive substring match over entity
-names, applied within the scope the chips establish.
+filter. **Tags** — exact, type-scoped filters — can only be created by selecting
+an autosuggest suggestion, are rendered as atomic non-editable, non-copyable
+chips (showing `type: value`), and combine by narrowing down the topology
+hierarchy (always AND, at most one chip per node type). Free text typed
+alongside the chips is a case-insensitive substring match over entity names,
+applied within the scope the chips establish. The `[type: value]` bracket form
+is only a written notation for tags in this document; it is never rendered and
+not persisted.
 
 We chose this over a literal-bracket text box (where the user types
 `[connection: x]` as raw characters) because making chips the only producer of
@@ -14,10 +16,8 @@ tags eliminates a whole class of parser edge cases — unbalanced brackets,
 escaping `]`/`:` inside values, malformed half-typed tags — and guarantees
 every tag references a real, currently-loaded entity. The trade-off is a more
 complex suggestion builder and chip-management UI versus a regex over a text
-field. The bracket grammar still exists purely as the serialization contract
-between the raw value and the chip model; chips are deliberately not copyable so
-serialized strings never need to be re-parsed back into chips (no persistence or
-shareable-URL support in v1).
+field. Chips are deliberately not copyable, so there is no serialized string to
+re-parse back into chips (no persistence or shareable-URL support in v1).
 
 The set of available tag keys is derived **at runtime** from the distinct node
 `type`s present in the loaded topology, excluding structural

--- a/docs/adr/0004-topology-search-chip-model.md
+++ b/docs/adr/0004-topology-search-chip-model.md
@@ -1,0 +1,35 @@
+# Topology Navigator search uses an autosuggest-only chip model
+
+The Topology Navigator search is a chip/token input rather than a plain text
+filter. **Tags** — exact, type-scoped filters serialized as `[type: value]` —
+can only be created by selecting an autosuggest suggestion, are rendered as
+atomic non-editable, non-copyable chips, and combine by narrowing down the
+topology hierarchy (always AND, at most one chip per node type). Free text
+typed alongside the chips is a case-insensitive substring match over entity
+names, applied within the scope the chips establish.
+
+We chose this over a literal-bracket text box (where the user types
+`[connection: x]` as raw characters) because making chips the only producer of
+tags eliminates a whole class of parser edge cases — unbalanced brackets,
+escaping `]`/`:` inside values, malformed half-typed tags — and guarantees
+every tag references a real, currently-loaded entity. The trade-off is a more
+complex suggestion builder and chip-management UI versus a regex over a text
+field. The bracket grammar still exists purely as the serialization contract
+between the raw value and the chip model; chips are deliberately not copyable so
+serialized strings never need to be re-parsed back into chips (no persistence or
+shareable-URL support in v1).
+
+The set of available tag keys is derived **at runtime** from the distinct node
+`type`s present in the loaded topology, excluding structural
+`operational-grouping` nodes — so the keys automatically track which brokers and
+entity types are actually connected, with no hardcoded list. In the
+endpoint-selector dialog the search composes (AND) with the existing
+selectability filter, so suggested keys and values are derived from the
+already-filtered, selectable subset only.
+
+## Considered Options
+
+- **Literal-bracket text box** — rejected: brittle parsing, allows tags that
+  reference nothing, and surfaces malformed-query states to the user.
+- **Hardcoded tag-key list** — rejected: would drift from the actual node-type
+  taxonomy and need editing whenever a broker or entity type is added.

--- a/docs/adr/0005-vhost-dedicated-node-type.md
+++ b/docs/adr/0005-vhost-dedicated-node-type.md
@@ -1,0 +1,22 @@
+# RabbitMQ vhost gets a dedicated topology node type
+
+The RabbitMQ vhost node will be given its own `type` (e.g. `vhost`) in the
+backend topology contract, instead of sharing the generic
+`operational-grouping` type with the structural "Queues"/"Exchanges" group
+folders.
+
+This is driven by the Topology Navigator search (see
+[ADR-0004](./0004-topology-search-chip-model.md)): tag keys are derived at
+runtime from node `type`s, with `operational-grouping` excluded as structural.
+A vhost is a real, addressable entity users want to scope a search by, but while
+it carries the generic grouping type it is indistinguishable from the
+non-addressable folder nodes. Giving it a distinct type lets it appear as a
+`vhost:` tag key for free, without special-casing the vhost path in the search
+layer.
+
+The alternative — keeping the shared type and special-casing "an
+`operational-grouping` node at the vhost path level" inside the search code —
+was rejected because it leaks a topology-shape assumption into the search
+feature and would have to be maintained in lockstep with the path structure.
+The cost is a backend contract change touching the RabbitMQ topology provider
+and any consumer that switches on node `type`.

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,6 +23,8 @@ Welcome to the documentation for Servicebus Browser. This repository contains in
 - [ADR-0001: Single active Workspace at a time](./adr/0001-single-active-workspace.md)
 - [ADR-0002: Workspace persistence via foreign-key namespacing](./adr/0002-workspace-persistence-foreign-key-namespacing.md)
 - [ADR-0003: Hard-cancel active receivers on Workspace switch](./adr/0003-hard-cancel-receivers-on-workspace-switch.md)
+- [ADR-0004: Topology Navigator search uses an autosuggest-only chip model](./adr/0004-topology-search-chip-model.md)
+- [ADR-0005: RabbitMQ vhost gets a dedicated topology node type](./adr/0005-vhost-dedicated-node-type.md)
 
 ## Project Structure
 

--- a/libs/backend/messaging-brokers/rabbitmq/clients/src/lib/rabbitmq-topology-provider.ts
+++ b/libs/backend/messaging-brokers/rabbitmq/clients/src/lib/rabbitmq-topology-provider.ts
@@ -178,7 +178,7 @@ export class RabbitMqTopologyProvider implements TopologyProvider {
       name: vhostName,
       refreshable: true,
       selectable: false,
-      type: 'operational-grouping',
+      type: 'vhost',
       children: [queuesNode, exchangesNode],
     };
   }

--- a/libs/topology/components/src/lib/generic-tree-node/generic-tree-node.component.html
+++ b/libs/topology/components/src/lib/generic-tree-node/generic-tree-node.component.html
@@ -9,7 +9,13 @@
     @if (node().icon; as icon) {
       <fa-icon [icon]="icon"></fa-icon>
     }
-    {{ node().name }}
+    @for (part of highlightParts(); track $index) {
+      @if (part.highlight) {
+        <mark class="search-highlight">{{ part.text }}</mark>
+      } @else {
+        {{ part.text }}
+      }
+    }
   </span>
   @if (showMessageCounts()) {
     <span [pTooltip]="messageCountToolTip">{{messageCountSummary()}}</span>

--- a/libs/topology/components/src/lib/generic-tree-node/generic-tree-node.component.scss
+++ b/libs/topology/components/src/lib/generic-tree-node/generic-tree-node.component.scss
@@ -22,6 +22,13 @@ span {
   flex: 1;
   overflow: hidden;
   text-overflow: ellipsis;
+
+  mark.search-highlight {
+    background-color: var(--p-highlight-background, #fff3cd);
+    color: inherit;
+    border-radius: 2px;
+    padding: 0 1px;
+  }
 }
 
 .spin {

--- a/libs/topology/components/src/lib/generic-tree-node/generic-tree-node.component.ts
+++ b/libs/topology/components/src/lib/generic-tree-node/generic-tree-node.component.ts
@@ -32,15 +32,33 @@ export class GenericTreeNodeComponent {
   node = input.required<TopologyNode>();
   selectionMode = input.required<'actions' | 'send' | 'none'>();
   searchTerm = input<string>('');
+  /**
+   * When true the entire node name is highlighted as an exact-match chip hit.
+   * Takes precedence over the substring highlight from `searchTerm`.
+   */
+  exactMatch = input<boolean>(false);
 
   actionSelected = output<TopologyAction>();
   sendEndpointSelected = output<SendEndpoint>();
   receiveEndpointSelected = output<ReceiveEndpoint>();
   clearReceiveEndpointSelected = output<ReceiveEndpoint>();
 
-  // Breaks node.name into [{text, highlight}] segments for substring highlight rendering
+  /**
+   * Breaks node.name into [{text, highlight}] segments for rendering.
+   *
+   * Priority:
+   *  1. exactMatch=true  → whole name is one highlighted segment (chip hit).
+   *  2. searchTerm set   → substring highlight as before.
+   *  3. Neither          → plain text.
+   */
   highlightParts = computed<{ text: string; highlight: boolean }[]>(() => {
     const name = this.node().name;
+
+    // Exact-match (chip hit): highlight the entire name
+    if (this.exactMatch()) {
+      return [{ text: name, highlight: true }];
+    }
+
     const term = this.searchTerm().trim().toLowerCase();
     if (!term) {
       return [{ text: name, highlight: false }];

--- a/libs/topology/components/src/lib/generic-tree-node/generic-tree-node.component.ts
+++ b/libs/topology/components/src/lib/generic-tree-node/generic-tree-node.component.ts
@@ -31,11 +31,35 @@ export class GenericTreeNodeComponent {
 
   node = input.required<TopologyNode>();
   selectionMode = input.required<'actions' | 'send' | 'none'>();
+  searchTerm = input<string>('');
 
   actionSelected = output<TopologyAction>();
   sendEndpointSelected = output<SendEndpoint>();
   receiveEndpointSelected = output<ReceiveEndpoint>();
   clearReceiveEndpointSelected = output<ReceiveEndpoint>();
+
+  // Breaks node.name into [{text, highlight}] segments for substring highlight rendering
+  highlightParts = computed<{ text: string; highlight: boolean }[]>(() => {
+    const name = this.node().name;
+    const term = this.searchTerm().trim().toLowerCase();
+    if (!term) {
+      return [{ text: name, highlight: false }];
+    }
+    const lowerName = name.toLowerCase();
+    const idx = lowerName.indexOf(term);
+    if (idx === -1) {
+      return [{ text: name, highlight: false }];
+    }
+    const parts: { text: string; highlight: boolean }[] = [];
+    if (idx > 0) {
+      parts.push({ text: name.slice(0, idx), highlight: false });
+    }
+    parts.push({ text: name.slice(idx, idx + term.length), highlight: true });
+    if (idx + term.length < name.length) {
+      parts.push({ text: name.slice(idx + term.length), highlight: false });
+    }
+    return parts;
+  });
 
   isLoading = toSignal(
     toObservable(this.node).pipe(

--- a/libs/topology/components/src/lib/search/search-query.model.spec.ts
+++ b/libs/topology/components/src/lib/search/search-query.model.spec.ts
@@ -3,6 +3,7 @@ import {
   rankByPrefix,
   resolveAcceleratorType,
   SUGGESTION_GROUP_CAP,
+  SUGGESTION_TOTAL_CAP,
 } from './search-query.model';
 
 describe('flattenTypeKey', () => {
@@ -96,13 +97,19 @@ describe('rankByPrefix', () => {
   });
 });
 
-describe('SUGGESTION_GROUP_CAP', () => {
+describe('SUGGESTION_TOTAL_CAP', () => {
   it('is a positive integer', () => {
-    expect(SUGGESTION_GROUP_CAP).toBeGreaterThan(0);
-    expect(Number.isInteger(SUGGESTION_GROUP_CAP)).toBe(true);
+    expect(SUGGESTION_TOTAL_CAP).toBeGreaterThan(0);
+    expect(Number.isInteger(SUGGESTION_TOTAL_CAP)).toBe(true);
   });
 
   it('is 10', () => {
-    expect(SUGGESTION_GROUP_CAP).toBe(10);
+    expect(SUGGESTION_TOTAL_CAP).toBe(10);
+  });
+});
+
+describe('SUGGESTION_GROUP_CAP (deprecated alias)', () => {
+  it('equals SUGGESTION_TOTAL_CAP for backward compatibility', () => {
+    expect(SUGGESTION_GROUP_CAP).toBe(SUGGESTION_TOTAL_CAP);
   });
 });

--- a/libs/topology/components/src/lib/search/search-query.model.spec.ts
+++ b/libs/topology/components/src/lib/search/search-query.model.spec.ts
@@ -1,0 +1,108 @@
+import {
+  flattenTypeKey,
+  rankByPrefix,
+  resolveAcceleratorType,
+  SUGGESTION_GROUP_CAP,
+} from './search-query.model';
+
+describe('flattenTypeKey', () => {
+  it('lowercases a simple key', () => {
+    expect(flattenTypeKey('exchange')).toBe('exchange');
+  });
+
+  it('flattens camelCase eventHub → eventhub', () => {
+    expect(flattenTypeKey('eventHub')).toBe('eventhub');
+  });
+
+  it('flattens camelCase consumerGroup → consumergroup', () => {
+    expect(flattenTypeKey('consumerGroup')).toBe('consumergroup');
+  });
+
+  it('flattens PascalCase Connection → connection', () => {
+    expect(flattenTypeKey('Connection')).toBe('connection');
+  });
+});
+
+describe('resolveAcceleratorType', () => {
+  const available = ['connection', 'exchange', 'eventHub', 'consumerGroup', 'queue'];
+
+  it('resolves an exact lowercase key', () => {
+    expect(resolveAcceleratorType('connection', available)).toBe('connection');
+  });
+
+  it('resolves exchange in lowercase', () => {
+    expect(resolveAcceleratorType('exchange', available)).toBe('exchange');
+  });
+
+  it('resolves eventhub (flattened) to eventHub', () => {
+    expect(resolveAcceleratorType('eventhub', available)).toBe('eventHub');
+  });
+
+  it('resolves consumergroup (flattened) to consumerGroup', () => {
+    expect(resolveAcceleratorType('consumergroup', available)).toBe('consumerGroup');
+  });
+
+  it('is case-insensitive for user input EVENTHUB', () => {
+    expect(resolveAcceleratorType('EVENTHUB', available)).toBe('eventHub');
+  });
+
+  it('returns null for unknown keys', () => {
+    expect(resolveAcceleratorType('unknown', available)).toBeNull();
+  });
+
+  it('returns null for empty string', () => {
+    expect(resolveAcceleratorType('', available)).toBeNull();
+  });
+});
+
+describe('rankByPrefix', () => {
+  const names = ['apple', 'Apricot', 'banana', 'avocado', 'cherry', 'Application'];
+
+  it('places prefix matches before substring-only matches', () => {
+    const result = rankByPrefix(names, 'app');
+    const prefixGroup = result.filter((n) => n.toLowerCase().startsWith('app'));
+    const substrGroup = result.filter((n) => !n.toLowerCase().startsWith('app'));
+    const lastPrefixIdx = Math.max(...prefixGroup.map((n) => result.indexOf(n)));
+    const firstSubstrIdx = Math.min(...substrGroup.map((n) => result.indexOf(n)));
+    // All prefix matches must come before any substring-only match
+    expect(lastPrefixIdx).toBeLessThan(firstSubstrIdx);
+  });
+
+  it('sorts alphabetically within each tier', () => {
+    const result = rankByPrefix(['zebra', 'zoo', 'zap'], 'z');
+    // All are prefix matches, so alphabetical order expected
+    expect(result).toEqual(['zap', 'zebra', 'zoo']);
+  });
+
+  it('handles empty fragment — all treated as prefix, alphabetical', () => {
+    const result = rankByPrefix(['banana', 'apple', 'cherry'], '');
+    expect(result).toEqual(['apple', 'banana', 'cherry']);
+  });
+
+  it('returns empty array for no names', () => {
+    expect(rankByPrefix([], 'foo')).toEqual([]);
+  });
+
+  it('handles names that only match as substring', () => {
+    const result = rankByPrefix(['pineapple', 'snapple', 'grapple'], 'apple');
+    // None start with 'apple', so all are substring matches, alphabetical
+    expect(result).toEqual(['grapple', 'pineapple', 'snapple']);
+  });
+
+  it('a name starting with fragment (case-insensitive) ranks above one that only contains it', () => {
+    const result = rankByPrefix(['pineapple', 'Apple'], 'apple');
+    expect(result[0]).toBe('Apple');
+    expect(result[1]).toBe('pineapple');
+  });
+});
+
+describe('SUGGESTION_GROUP_CAP', () => {
+  it('is a positive integer', () => {
+    expect(SUGGESTION_GROUP_CAP).toBeGreaterThan(0);
+    expect(Number.isInteger(SUGGESTION_GROUP_CAP)).toBe(true);
+  });
+
+  it('is 10', () => {
+    expect(SUGGESTION_GROUP_CAP).toBe(10);
+  });
+});

--- a/libs/topology/components/src/lib/search/search-query.model.ts
+++ b/libs/topology/components/src/lib/search/search-query.model.ts
@@ -38,12 +38,10 @@ export const EXCLUDED_TAG_TYPES = new Set(['operational-grouping', 'no-children'
  * A blended suggestion item shown in the autocomplete dropdown.
  *
  * `kind === 'entity'`     — selecting this creates a chip {type, value}.
- * `kind === 'freeText'`   — selecting this commits the text as trailing free text.
  * `kind === 'truncation'` — non-selectable informational row ("showing N of M").
  */
 export type SuggestionItem =
   | { kind: 'entity'; type: string; label: string; groupLabel: string }
-  | { kind: 'freeText'; text: string; label: string }
   | { kind: 'truncation'; label: string };
 
 /**
@@ -56,8 +54,14 @@ export interface SuggestionGroup {
 
 // ── Suggestion helpers ────────────────────────────────────────────────────────
 
-/** Maximum entity items shown per type group before a truncation hint appears. */
-export const SUGGESTION_GROUP_CAP = 10;
+/** Maximum total entity items shown across ALL type groups in the dropdown. */
+export const SUGGESTION_TOTAL_CAP = 10;
+
+/**
+ * @deprecated Use SUGGESTION_TOTAL_CAP. Kept for any external references.
+ * @internal
+ */
+export const SUGGESTION_GROUP_CAP = SUGGESTION_TOTAL_CAP;
 
 /**
  * Ranks a list of entity names by relevance to `fragment`:

--- a/libs/topology/components/src/lib/search/search-query.model.ts
+++ b/libs/topology/components/src/lib/search/search-query.model.ts
@@ -37,12 +37,14 @@ export const EXCLUDED_TAG_TYPES = new Set(['operational-grouping', 'no-children'
 /**
  * A blended suggestion item shown in the autocomplete dropdown.
  *
- * `kind === 'entity'` — selecting this creates a chip {type, value}.
- * `kind === 'freeText'` — selecting this commits the text as trailing free text.
+ * `kind === 'entity'`     — selecting this creates a chip {type, value}.
+ * `kind === 'freeText'`   — selecting this commits the text as trailing free text.
+ * `kind === 'truncation'` — non-selectable informational row ("showing N of M").
  */
 export type SuggestionItem =
   | { kind: 'entity'; type: string; label: string; groupLabel: string }
-  | { kind: 'freeText'; text: string; label: string };
+  | { kind: 'freeText'; text: string; label: string }
+  | { kind: 'truncation'; label: string };
 
 /**
  * A grouped suggestion row passed to PrimeNG AutoComplete when `[group]="true"`.
@@ -50,4 +52,61 @@ export type SuggestionItem =
 export interface SuggestionGroup {
   groupLabel: string;
   items: SuggestionItem[];
+}
+
+// ── Suggestion helpers ────────────────────────────────────────────────────────
+
+/** Maximum entity items shown per type group before a truncation hint appears. */
+export const SUGGESTION_GROUP_CAP = 10;
+
+/**
+ * Ranks a list of entity names by relevance to `fragment`:
+ *  1. Prefix matches  (name starts with fragment, case-insensitive) — ranked first.
+ *  2. Substring matches (name contains fragment but does not start with it) — ranked second.
+ * Within each tier the order is alphabetical.
+ *
+ * When `fragment` is empty every name is treated as a prefix match so the list
+ * is returned in alphabetical order.
+ */
+export function rankByPrefix(names: string[], fragment: string): string[] {
+  const f = fragment.toLowerCase();
+  const prefix: string[] = [];
+  const substr: string[] = [];
+  for (const name of names) {
+    const n = name.toLowerCase();
+    if (f === '' || n.startsWith(f)) {
+      prefix.push(name);
+    } else {
+      substr.push(name);
+    }
+  }
+  prefix.sort((a, b) => a.localeCompare(b));
+  substr.sort((a, b) => a.localeCompare(b));
+  return [...prefix, ...substr];
+}
+
+/**
+ * Given a camelCase / PascalCase type key (e.g. `eventHub`, `consumerGroup`)
+ * returns a lower-case "flattened" form (`eventhub`, `consumergroup`) suitable
+ * for case-insensitive accelerator matching where the user types without spaces.
+ */
+export function flattenTypeKey(type: string): string {
+  return type.toLowerCase();
+}
+
+/**
+ * Given the user-typed prefix up to (and including) the first colon, extract
+ * the intended tag key and return the matching runtime type (from `availableTypes`)
+ * or `null` if no match.
+ *
+ * Matching is done by comparing the flattened forms so that `exchange:` matches
+ * `exchange`, `eventhub:` matches `eventHub`, `consumergroup:` matches
+ * `consumerGroup`, etc.
+ */
+export function resolveAcceleratorType(
+  keyFragment: string,
+  availableTypes: string[],
+): string | null {
+  const needle = flattenTypeKey(keyFragment);
+  return availableTypes.find((t) => flattenTypeKey(t) === needle) ?? null;
 }

--- a/libs/topology/components/src/lib/search/search-query.model.ts
+++ b/libs/topology/components/src/lib/search/search-query.model.ts
@@ -3,8 +3,9 @@
  * Created only by selecting an autosuggest suggestion (never typed raw).
  * At most one chip per node type is present in the query at any time.
  *
- * Serialization: `[type: value]`  (internal contract / display only — chips
- * are not copyable and there is no persistence in v1).
+ * The `[type: value]` bracket form is only a textual notation used in design
+ * discussion; it is never rendered (the pill shows `type: value`) and there is
+ * no persistence in v1.
  */
 export interface SearchChip {
   type: string;
@@ -20,11 +21,6 @@ export interface SearchQuery {
 }
 
 export const EMPTY_QUERY: SearchQuery = { chips: [], freeText: '' };
-
-/** Serialize a chip to its canonical bracket form, e.g. "[connection: my-conn]" */
-export function serializeChip(chip: SearchChip): string {
-  return `[${chip.type}: ${chip.value}]`;
-}
 
 /** True when the query has no chips and no free text. */
 export function isQueryEmpty(query: SearchQuery): boolean {

--- a/libs/topology/components/src/lib/search/search-query.model.ts
+++ b/libs/topology/components/src/lib/search/search-query.model.ts
@@ -1,0 +1,53 @@
+/**
+ * A Search Tag chip — an exact, type-scoped filter.
+ * Created only by selecting an autosuggest suggestion (never typed raw).
+ * At most one chip per node type is present in the query at any time.
+ *
+ * Serialization: `[type: value]`  (internal contract / display only — chips
+ * are not copyable and there is no persistence in v1).
+ */
+export interface SearchChip {
+  type: string;
+  value: string;
+}
+
+/**
+ * The full search query: an ordered list of chips PLUS a trailing free-text string.
+ */
+export interface SearchQuery {
+  chips: SearchChip[];
+  freeText: string;
+}
+
+export const EMPTY_QUERY: SearchQuery = { chips: [], freeText: '' };
+
+/** Serialize a chip to its canonical bracket form, e.g. "[connection: my-conn]" */
+export function serializeChip(chip: SearchChip): string {
+  return `[${chip.type}: ${chip.value}]`;
+}
+
+/** True when the query has no chips and no free text. */
+export function isQueryEmpty(query: SearchQuery): boolean {
+  return query.chips.length === 0 && query.freeText.trim() === '';
+}
+
+/** Structural node types that must never appear as tag keys. */
+export const EXCLUDED_TAG_TYPES = new Set(['operational-grouping', 'no-children']);
+
+/**
+ * A blended suggestion item shown in the autocomplete dropdown.
+ *
+ * `kind === 'entity'` — selecting this creates a chip {type, value}.
+ * `kind === 'freeText'` — selecting this commits the text as trailing free text.
+ */
+export type SuggestionItem =
+  | { kind: 'entity'; type: string; label: string; groupLabel: string }
+  | { kind: 'freeText'; text: string; label: string };
+
+/**
+ * A grouped suggestion row passed to PrimeNG AutoComplete when `[group]="true"`.
+ */
+export interface SuggestionGroup {
+  groupLabel: string;
+  items: SuggestionItem[];
+}

--- a/libs/topology/components/src/lib/topology-tree/topology-tree.component.html
+++ b/libs/topology/components/src/lib/topology-tree/topology-tree.component.html
@@ -27,6 +27,7 @@
       optionGroupChildren="items"
       [minLength]="0"
       [completeOnFocus]="true"
+      [showEmptyMessage]="false"
       [forceSelection]="false"
       [delay]="0"
       [placeholder]="currentChips().length === 0 ? 'Search' : 'Add filter…'"

--- a/libs/topology/components/src/lib/topology-tree/topology-tree.component.html
+++ b/libs/topology/components/src/lib/topology-tree/topology-tree.component.html
@@ -33,6 +33,7 @@
       appendTo="body"
       (completeMethod)="onComplete($event)"
       (onSelect)="onSuggestionSelect($event)"
+      (onClear)="onSearchCleared()"
     >
       <!-- Item template: entity row or truncation hint -->
       <ng-template let-item pTemplate="item">

--- a/libs/topology/components/src/lib/topology-tree/topology-tree.component.html
+++ b/libs/topology/components/src/lib/topology-tree/topology-tree.component.html
@@ -1,21 +1,58 @@
 <div class="main-container">
   <div class="search-container">
-    <input
-      pInputText
-      [(ngModel)]="searchTerm"
-      placeholder="Search"
-      class="search-input"
-      [pTooltip]="searchTooltip"
-      [tooltipOptions]="{
-       tooltipEvent: 'focus',
-       appendTo: 'body',
-       disabled: searchTerm() !== ''
-       }"
-    />
+    <!-- Chip display area (chips are managed manually, above the autocomplete) -->
+    @if (currentChips().length > 0) {
+      <div class="chip-list">
+        @for (chip of currentChips(); track chip.type) {
+          <span class="search-chip">
+            <span class="chip-label">{{ chipLabel(chip) }}</span>
+            <button
+              class="chip-remove"
+              type="button"
+              aria-label="Remove filter"
+              (click)="removeChip(chip)"
+            >×</button>
+          </span>
+        }
+      </div>
+    }
+
+    <!-- Blended autosuggest input -->
+    <p-autocomplete
+      class="search-autocomplete"
+      [ngModel]="autocompleteValue()"
+      [suggestions]="suggestions()"
+      [group]="true"
+      optionGroupLabel="groupLabel"
+      optionGroupChildren="items"
+      [minLength]="0"
+      [completeOnFocus]="true"
+      [forceSelection]="true"
+      [delay]="0"
+      [placeholder]="currentChips().length === 0 ? 'Search' : 'Add filter…'"
+      appendTo="body"
+      (completeMethod)="onComplete($event)"
+      (onSelect)="onSuggestionSelect($event)"
+    >
+      <!-- Item template: entity row or free-text row -->
+      <ng-template let-item pTemplate="item">
+        @if (item.kind === 'entity') {
+          <span class="suggestion-entity">{{ item.label }}</span>
+        } @else {
+          <span class="suggestion-freetext">{{ item.label }}</span>
+        }
+      </ng-template>
+
+      <!-- Group header template -->
+      <ng-template let-group pTemplate="group">
+        <span class="suggestion-group-label">{{ group.groupLabel }}</span>
+      </ng-template>
+    </p-autocomplete>
   </div>
+
   <div class="tree-wrapper">
     @if (hasNoResults()) {
-      <div class="no-results">No results for "{{ debouncedSearchTerm() }}"</div>
+      <div class="no-results">No results</div>
     } @else {
       <p-tree
         [value]="treeNodes()"
@@ -33,7 +70,8 @@
             (sendEndpointSelected)="onSendEndpointSelected($event)"
             (clearReceiveEndpointSelected)="onClearReceiveEndpointSelected($event)"
             [selectionMode]="nodeSelectionMode()"
-            [searchTerm]="debouncedSearchTerm()"
+            [searchTerm]="debouncedFreeText()"
+            [exactMatch]="isExactChipMatch(node.data)"
           />
         </ng-template>
         <ng-template let-node pTemplate="no-children">
@@ -44,18 +82,6 @@
   </div>
 </div>
 
-<ng-template #searchTooltip>
-  <div>
-    <p>Search for a namespace, queue, topic or subscription by name</p>
-    <p>You can specify the type be prependinging your search term with the type name</p>
-    <p>e.g. <b>namespace:my-namespace</b></p>
-    <p>e.g. <b>queue:my-queue</b></p>
-    <p>e.g. <b>topic:my-topic</b></p>
-    <p>e.g. <b>subscription:my-subscription</b></p>
-  </div>
-</ng-template>
-
 <lib-receive-messages-dialog
   [(receiveEndpoint)]="selectedReceiveEndpoint"
 />
-

--- a/libs/topology/components/src/lib/topology-tree/topology-tree.component.html
+++ b/libs/topology/components/src/lib/topology-tree/topology-tree.component.html
@@ -34,10 +34,12 @@
       (completeMethod)="onComplete($event)"
       (onSelect)="onSuggestionSelect($event)"
     >
-      <!-- Item template: entity row or free-text row -->
+      <!-- Item template: entity row, free-text row, or truncation hint -->
       <ng-template let-item pTemplate="item">
         @if (item.kind === 'entity') {
           <span class="suggestion-entity">{{ item.label }}</span>
+        } @else if (item.kind === 'truncation') {
+          <span class="suggestion-truncation">{{ item.label }}</span>
         } @else {
           <span class="suggestion-freetext">{{ item.label }}</span>
         }

--- a/libs/topology/components/src/lib/topology-tree/topology-tree.component.html
+++ b/libs/topology/components/src/lib/topology-tree/topology-tree.component.html
@@ -27,21 +27,19 @@
       optionGroupChildren="items"
       [minLength]="0"
       [completeOnFocus]="true"
-      [forceSelection]="true"
+      [forceSelection]="false"
       [delay]="0"
       [placeholder]="currentChips().length === 0 ? 'Search' : 'Add filter…'"
       appendTo="body"
       (completeMethod)="onComplete($event)"
       (onSelect)="onSuggestionSelect($event)"
     >
-      <!-- Item template: entity row, free-text row, or truncation hint -->
+      <!-- Item template: entity row or truncation hint -->
       <ng-template let-item pTemplate="item">
         @if (item.kind === 'entity') {
           <span class="suggestion-entity">{{ item.label }}</span>
         } @else if (item.kind === 'truncation') {
           <span class="suggestion-truncation">{{ item.label }}</span>
-        } @else {
-          <span class="suggestion-freetext">{{ item.label }}</span>
         }
       </ng-template>
 

--- a/libs/topology/components/src/lib/topology-tree/topology-tree.component.html
+++ b/libs/topology/components/src/lib/topology-tree/topology-tree.component.html
@@ -14,28 +14,33 @@
     />
   </div>
   <div class="tree-wrapper">
-    <p-tree
-      [value]="treeNodes()"
-      (onNodeExpand)="onNodeExpand($event)"
-      (onNodeCollapse)="onNodeCollapse($event)"
-      selectionMode="multiple"
-      [selection]="treeSelection()"
-      (selectionChange)="onSelectionChange($event)"
-    >
-      <ng-template let-node pTemplate="default">
-        <sbb-tpl-generic-tree-node
-          [node]="node.data"
-          (actionSelected)="onActionSelected($event)"
-          (receiveEndpointSelected)="onReceiveEndpointSelected($event)"
-          (sendEndpointSelected)="onSendEndpointSelected($event)"
-          (clearReceiveEndpointSelected)="onClearReceiveEndpointSelected($event)"
-          [selectionMode]="nodeSelectionMode()"
-        />
-      </ng-template>
-      <ng-template let-node pTemplate="no-children">
-        <span class="children">No topology found</span>
-      </ng-template>
-    </p-tree>
+    @if (hasNoResults()) {
+      <div class="no-results">No results for "{{ debouncedSearchTerm() }}"</div>
+    } @else {
+      <p-tree
+        [value]="treeNodes()"
+        (onNodeExpand)="onNodeExpand($event)"
+        (onNodeCollapse)="onNodeCollapse($event)"
+        selectionMode="multiple"
+        [selection]="treeSelection()"
+        (selectionChange)="onSelectionChange($event)"
+      >
+        <ng-template let-node pTemplate="default">
+          <sbb-tpl-generic-tree-node
+            [node]="node.data"
+            (actionSelected)="onActionSelected($event)"
+            (receiveEndpointSelected)="onReceiveEndpointSelected($event)"
+            (sendEndpointSelected)="onSendEndpointSelected($event)"
+            (clearReceiveEndpointSelected)="onClearReceiveEndpointSelected($event)"
+            [selectionMode]="nodeSelectionMode()"
+            [searchTerm]="debouncedSearchTerm()"
+          />
+        </ng-template>
+        <ng-template let-node pTemplate="no-children">
+          <span class="children">No topology found</span>
+        </ng-template>
+      </p-tree>
+    }
   </div>
 </div>
 

--- a/libs/topology/components/src/lib/topology-tree/topology-tree.component.scss
+++ b/libs/topology/components/src/lib/topology-tree/topology-tree.component.scss
@@ -138,12 +138,6 @@ p-tree {
   font-size: 0.9rem;
 }
 
-.suggestion-freetext {
-  font-size: 0.9rem;
-  font-style: italic;
-  color: var(--p-text-muted-color, #6c757d);
-}
-
 // ── No results ─────────────────────────────────────────────────────────────
 
 .no-results {

--- a/libs/topology/components/src/lib/topology-tree/topology-tree.component.scss
+++ b/libs/topology/components/src/lib/topology-tree/topology-tree.component.scss
@@ -50,22 +50,101 @@ p-tree {
   color: red;
 }
 
+// ── Search container ──────────────────────────────────────────────────────
+
 .search-container {
   display: flex;
-  flex-direction: row;
-  align-items: stretch;
-  justify-content: stretch;
-  input {
-    flex: 1;
-    --p-inputtext-border-radius: 0;
+  flex-direction: column;
+  border-bottom: 1px solid var(--p-inputtext-border-color, #ced4da);
+}
+
+// ── Chips ─────────────────────────────────────────────────────────────────
+
+.chip-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.25rem;
+  padding: 0.35rem 0.5rem 0;
+}
+
+.search-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.2rem;
+  background: var(--p-highlight-background, #e9ecef);
+  color: var(--p-highlight-color, #212529);
+  border-radius: 1rem;
+  padding: 0.1rem 0.5rem;
+  font-size: 0.8rem;
+  white-space: nowrap;
+  max-width: 100%;
+
+  .chip-label {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    font-family: monospace;
+    font-size: 0.8rem;
+  }
+
+  .chip-remove {
+    all: unset;
+    cursor: pointer;
+    line-height: 1;
+    font-size: 1rem;
+    opacity: 0.6;
+    padding: 0 0.1rem;
+
+    &:hover {
+      opacity: 1;
+    }
   }
 }
 
-.search-input {
-  border-top: none;
-  border-left: none;
-  border-right: none;
+// ── AutoComplete input ─────────────────────────────────────────────────────
+
+.search-autocomplete {
+  width: 100%;
+
+  ::ng-deep .p-autocomplete {
+    width: 100%;
+  }
+
+  ::ng-deep .p-autocomplete-input {
+    width: 100%;
+    border-top: none;
+    border-left: none;
+    border-right: none;
+    border-bottom: none;
+    border-radius: 0;
+    box-shadow: none;
+
+    &:focus {
+      box-shadow: none;
+    }
+  }
 }
+
+// ── Suggestion dropdown ────────────────────────────────────────────────────
+
+.suggestion-group-label {
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--p-text-muted-color, #6c757d);
+}
+
+.suggestion-entity {
+  font-size: 0.9rem;
+}
+
+.suggestion-freetext {
+  font-size: 0.9rem;
+  font-style: italic;
+  color: var(--p-text-muted-color, #6c757d);
+}
+
+// ── No results ─────────────────────────────────────────────────────────────
 
 .no-results {
   padding: 1rem;
@@ -73,7 +152,6 @@ p-tree {
   font-style: italic;
   text-align: center;
 }
-
 
 @keyframes spin {
   from {transform:rotate(0deg);}

--- a/libs/topology/components/src/lib/topology-tree/topology-tree.component.scss
+++ b/libs/topology/components/src/lib/topology-tree/topology-tree.component.scss
@@ -67,6 +67,13 @@ p-tree {
   border-right: none;
 }
 
+.no-results {
+  padding: 1rem;
+  color: var(--p-text-muted-color, #6c757d);
+  font-style: italic;
+  text-align: center;
+}
+
 
 @keyframes spin {
   from {transform:rotate(0deg);}

--- a/libs/topology/components/src/lib/topology-tree/topology-tree.component.ts
+++ b/libs/topology/components/src/lib/topology-tree/topology-tree.component.ts
@@ -39,7 +39,6 @@ import {
   resolveAcceleratorType,
   SearchChip,
   SearchQuery,
-  serializeChip,
   SUGGESTION_TOTAL_CAP,
   SuggestionGroup,
   SuggestionItem,
@@ -565,9 +564,9 @@ export class TopologyTreeComponent {
     }));
   }
 
-  /** Serialize a chip for display in the chip token label. */
+  /** Human-readable label shown inside the chip pill (no brackets). */
   chipLabel(chip: SearchChip): string {
-    return serializeChip(chip);
+    return `${chip.type}: ${chip.value}`;
   }
 
   // ── Tree helpers ──────────────────────────────────────────────────────────

--- a/libs/topology/components/src/lib/topology-tree/topology-tree.component.ts
+++ b/libs/topology/components/src/lib/topology-tree/topology-tree.component.ts
@@ -40,7 +40,7 @@ import {
   SearchChip,
   SearchQuery,
   serializeChip,
-  SUGGESTION_GROUP_CAP,
+  SUGGESTION_TOTAL_CAP,
   SuggestionGroup,
   SuggestionItem,
 } from '../search/search-query.model';
@@ -376,18 +376,28 @@ export class TopologyTreeComponent {
    * behaviour, unchanged).
    *
    * In both modes:
+   * - Typed text drives live free-text tree filtering on every keystroke.
    * - Suggestions are chip-scoped (nodes must satisfy existing chips).
    * - Prefix matches rank above substring matches within each type group.
-   * - Each type group is capped at SUGGESTION_GROUP_CAP items; a
-   *   non-selectable truncation hint row is appended when the cap is reached.
-   * - The always-present free-text row is appended last.
+   * - At most SUGGESTION_TOTAL_CAP entity rows are shown in total across all groups.
+   * - Suggestions are only shown when the typed query is >= 3 characters.
    */
   onComplete(event: AutoCompleteCompleteEvent) {
     const typed = event.query.trim();
+
+    // Point 1: drive live free-text filtering from every keystroke
+    this.searchInputText.set(typed);
+
     const chips = this.searchQuery().chips;
 
     // Types that already have a chip — never offered again
     const usedTypes = new Set(chips.map((c) => c.type));
+
+    // Point 3: only build and show tag suggestions when >=3 chars are typed
+    if (typed.length < 3) {
+      this.suggestions.set([]);
+      return;
+    }
 
     // ── Accelerator detection ──────────────────────────────────────────────
     // Determine the set of runtime tag keys (non-excluded, non-structural types
@@ -465,18 +475,23 @@ export class TopologyTreeComponent {
       walkForSuggestions(root, []),
     );
 
-    // ── Build suggestion groups ────────────────────────────────────────────
+    // ── Build suggestion groups with a TOTAL cap of SUGGESTION_TOTAL_CAP ──
+    // Point 4: at most SUGGESTION_TOTAL_CAP entity rows in total across all groups.
     const groups: SuggestionGroup[] = [];
 
     // Determine the fragment used for ranking inside each group
     const rankFragment = acceleratorType !== null ? valueFragment : typed;
 
+    let remaining = SUGGESTION_TOTAL_CAP;
+
     for (const [type, names] of grouped) {
+      if (remaining <= 0) break;
+
       // Rank: prefix matches first, then substring; alphabetical within tiers
       const ranked = rankByPrefix(names, rankFragment);
 
-      const totalCount = ranked.length;
-      const capped = ranked.slice(0, SUGGESTION_GROUP_CAP);
+      const capped = ranked.slice(0, remaining);
+      remaining -= capped.length;
 
       const items: SuggestionItem[] = capped.map((name) => ({
         kind: 'entity' as const,
@@ -485,23 +500,10 @@ export class TopologyTreeComponent {
         groupLabel: type,
       }));
 
-      // Non-silent truncation hint
-      if (totalCount > SUGGESTION_GROUP_CAP) {
-        items.push({
-          kind: 'truncation' as const,
-          label: `showing ${SUGGESTION_GROUP_CAP} of ${totalCount}`,
-        });
-      }
-
       groups.push({ groupLabel: type, items });
     }
 
-    // Always-present free-text row
-    const freeTextLabel = typed ? `Search for "${typed}"` : 'Type to search…';
-    groups.push({
-      groupLabel: 'free text',
-      items: [{ kind: 'freeText' as const, text: typed, label: freeTextLabel }],
-    });
+    // Point 2: NO free-text row is ever added to the dropdown.
 
     this.suggestions.set(groups);
   }
@@ -536,15 +538,13 @@ export class TopologyTreeComponent {
     if (item.kind === 'entity') {
       const newChip: SearchChip = { type: item.type, value: item.label };
       this.searchQuery.update((q) => ({
+        // Point 5: clear freeText when a chip is created
         chips: [...q.chips, newChip],
-        freeText: q.freeText,
+        freeText: '',
       }));
-      // Clear the text field after chip creation
+      // Point 5: reset live free-text signal and push empty through debounce
       this.searchInputText.set('');
-    } else if (item.kind === 'freeText') {
-      // Free-text row
-      this.searchInputText.set(item.text);
-      this.searchQuery.update((q) => ({ ...q, freeText: item.text }));
+      this.freeText$.next('');
     }
     // 'truncation' items are informational only — clicking them is a no-op.
 

--- a/libs/topology/components/src/lib/topology-tree/topology-tree.component.ts
+++ b/libs/topology/components/src/lib/topology-tree/topology-tree.component.ts
@@ -35,9 +35,12 @@ import {
   EMPTY_QUERY,
   EXCLUDED_TAG_TYPES,
   isQueryEmpty,
+  rankByPrefix,
+  resolveAcceleratorType,
   SearchChip,
   SearchQuery,
   serializeChip,
+  SUGGESTION_GROUP_CAP,
   SuggestionGroup,
   SuggestionItem,
 } from '../search/search-query.model';
@@ -359,7 +362,25 @@ export class TopologyTreeComponent {
 
   /**
    * Called by PrimeNG AutoComplete on every keystroke.
-   * Builds a blended list of entity suggestions + a free-text row.
+   *
+   * Two modes:
+   *
+   * **Accelerator mode** — the typed fragment starts with a known tag-key
+   * immediately followed by a colon (e.g. `exchange:`, `eventHub:rabbit`).
+   * Only entity suggestions of that single type are shown, filtered by the
+   * value portion after the colon.  If that type already has a chip, no
+   * entity rows are emitted (one-chip-per-type still applies).
+   *
+   * **Blended mode** — the fragment does NOT start with `key:`.  All eligible
+   * entity types are shown, each filtered by the full fragment (existing
+   * behaviour, unchanged).
+   *
+   * In both modes:
+   * - Suggestions are chip-scoped (nodes must satisfy existing chips).
+   * - Prefix matches rank above substring matches within each type group.
+   * - Each type group is capped at SUGGESTION_GROUP_CAP items; a
+   *   non-selectable truncation hint row is appended when the cap is reached.
+   * - The always-present free-text row is appended last.
    */
   onComplete(event: AutoCompleteCompleteEvent) {
     const typed = event.query.trim();
@@ -368,41 +389,68 @@ export class TopologyTreeComponent {
     // Types that already have a chip — never offered again
     const usedTypes = new Set(chips.map((c) => c.type));
 
-    // Collect entity suggestions, scoped by current chips
-    const grouped = new Map<string, string[]>(); // type → matching names
+    // ── Accelerator detection ──────────────────────────────────────────────
+    // Determine the set of runtime tag keys (non-excluded, non-structural types
+    // present in selectabilityFilteredNodes).
+    const availableTypes = this.collectAvailableTypes();
+
+    // Does the typed fragment start with "<key>:" (key is a known type)?
+    let acceleratorType: string | null = null;
+    let valueFragment = '';
+    const colonIdx = typed.indexOf(':');
+    if (colonIdx > 0) {
+      const keyPart = typed.slice(0, colonIdx);
+      const resolved = resolveAcceleratorType(keyPart, availableTypes);
+      if (resolved !== null) {
+        acceleratorType = resolved;
+        valueFragment = typed.slice(colonIdx + 1).trimStart();
+      }
+    }
+
+    // ── Collect matching names per type ────────────────────────────────────
+    // In accelerator mode we only collect for the resolved type;
+    // in blended mode we collect for all non-used types.
+    const grouped = new Map<string, string[]>(); // type → de-duped names (unranked)
 
     const walkForSuggestions = (
       node: TopologyNode,
       ancestorPath: TopologyNode[],
     ) => {
       if (EXCLUDED_TAG_TYPES.has(node.type)) {
-        // Still descend to find children
         node.children?.forEach((c) =>
           walkForSuggestions(c, [...ancestorPath, node]),
         );
         return;
       }
 
-      if (!usedTypes.has(node.type)) {
-        // Check whether this node satisfies the current chips in its ancestor path
-        const allNodes = [...ancestorPath, node];
-        const satisfiesChips = chips.every((chip) =>
-          allNodes.some(
-            (n) =>
-              n.type === chip.type &&
-              n.name.toLowerCase() === chip.value.toLowerCase(),
-          ),
-        );
+      const isTargetType = acceleratorType !== null
+        ? node.type === acceleratorType
+        : !usedTypes.has(node.type);
 
-        if (satisfiesChips) {
-          const nameLower = node.name.toLowerCase();
-          const typedLower = typed.toLowerCase();
-          if (typed === '' || nameLower.includes(typedLower)) {
-            const list = grouped.get(node.type) ?? [];
-            // Deduplicate by name within the type group
-            if (!list.includes(node.name)) {
-              list.push(node.name);
-              grouped.set(node.type, list);
+      if (isTargetType) {
+        // Skip if type already has a chip (one-chip-per-type)
+        if (!usedTypes.has(node.type)) {
+          // Check chip scoping
+          const allNodes = [...ancestorPath, node];
+          const satisfiesChips = chips.every((chip) =>
+            allNodes.some(
+              (n) =>
+                n.type === chip.type &&
+                n.name.toLowerCase() === chip.value.toLowerCase(),
+            ),
+          );
+
+          if (satisfiesChips) {
+            // In accelerator mode filter by valueFragment; in blended mode by typed
+            const filterFragment = acceleratorType !== null ? valueFragment : typed;
+            const nameLower = node.name.toLowerCase();
+            const fragmentLower = filterFragment.toLowerCase();
+            if (filterFragment === '' || nameLower.includes(fragmentLower)) {
+              const list = grouped.get(node.type) ?? [];
+              if (!list.includes(node.name)) {
+                list.push(node.name);
+                grouped.set(node.type, list);
+              }
             }
           }
         }
@@ -417,36 +465,62 @@ export class TopologyTreeComponent {
       walkForSuggestions(root, []),
     );
 
+    // ── Build suggestion groups ────────────────────────────────────────────
     const groups: SuggestionGroup[] = [];
 
+    // Determine the fragment used for ranking inside each group
+    const rankFragment = acceleratorType !== null ? valueFragment : typed;
+
     for (const [type, names] of grouped) {
-      groups.push({
+      // Rank: prefix matches first, then substring; alphabetical within tiers
+      const ranked = rankByPrefix(names, rankFragment);
+
+      const totalCount = ranked.length;
+      const capped = ranked.slice(0, SUGGESTION_GROUP_CAP);
+
+      const items: SuggestionItem[] = capped.map((name) => ({
+        kind: 'entity' as const,
+        type,
+        label: name,
         groupLabel: type,
-        items: names.map((name) => ({
-          kind: 'entity' as const,
-          type,
-          label: name,
-          groupLabel: type,
-        })),
-      });
+      }));
+
+      // Non-silent truncation hint
+      if (totalCount > SUGGESTION_GROUP_CAP) {
+        items.push({
+          kind: 'truncation' as const,
+          label: `showing ${SUGGESTION_GROUP_CAP} of ${totalCount}`,
+        });
+      }
+
+      groups.push({ groupLabel: type, items });
     }
 
     // Always-present free-text row
-    const freeTextLabel = typed
-      ? `Search for "${typed}"`
-      : 'Type to search…';
+    const freeTextLabel = typed ? `Search for "${typed}"` : 'Type to search…';
     groups.push({
       groupLabel: 'free text',
-      items: [
-        {
-          kind: 'freeText' as const,
-          text: typed,
-          label: freeTextLabel,
-        },
-      ],
+      items: [{ kind: 'freeText' as const, text: typed, label: freeTextLabel }],
     });
 
     this.suggestions.set(groups);
+  }
+
+  /**
+   * Collect the set of distinct node types present in selectabilityFilteredNodes,
+   * excluding structural / excluded types.  Used by onComplete() to derive the
+   * runtime accelerator key set.
+   */
+  private collectAvailableTypes(): string[] {
+    const types = new Set<string>();
+    const walk = (node: TopologyNode) => {
+      if (!EXCLUDED_TAG_TYPES.has(node.type)) {
+        types.add(node.type);
+      }
+      node.children?.forEach(walk);
+    };
+    this.selectabilityFilteredNodes().forEach(walk);
+    return [...types];
   }
 
   /**
@@ -467,11 +541,12 @@ export class TopologyTreeComponent {
       }));
       // Clear the text field after chip creation
       this.searchInputText.set('');
-    } else {
+    } else if (item.kind === 'freeText') {
       // Free-text row
       this.searchInputText.set(item.text);
       this.searchQuery.update((q) => ({ ...q, freeText: item.text }));
     }
+    // 'truncation' items are informational only — clicking them is a no-op.
 
     // Reset the autocomplete's visible value back to empty so the field is clear
     this.autocompleteValue.set([]);

--- a/libs/topology/components/src/lib/topology-tree/topology-tree.component.ts
+++ b/libs/topology/components/src/lib/topology-tree/topology-tree.component.ts
@@ -381,6 +381,17 @@ export class TopologyTreeComponent {
    * - At most SUGGESTION_TOTAL_CAP entity rows are shown in total across all groups.
    * - Suggestions are only shown when the typed query is >= 3 characters.
    */
+  /**
+   * PrimeNG emits (onClear) when the input is emptied (including via backspace),
+   * and in that case it does NOT call completeMethod — so we must reset the
+   * free-text filter here, otherwise the last term keeps filtering/highlighting.
+   */
+  onSearchCleared() {
+    this.searchInputText.set('');
+    this.freeText$.next('');
+    this.suggestions.set([]);
+  }
+
   onComplete(event: AutoCompleteCompleteEvent) {
     const typed = event.query.trim();
 

--- a/libs/topology/components/src/lib/topology-tree/topology-tree.component.ts
+++ b/libs/topology/components/src/lib/topology-tree/topology-tree.component.ts
@@ -13,8 +13,6 @@ import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { Tree, TreeNodeCollapseEvent, TreeNodeExpandEvent } from 'primeng/tree';
 import { PrimeTemplate, TreeNode } from 'primeng/api';
-import { InputText } from 'primeng/inputtext';
-import { Tooltip } from 'primeng/tooltip';
 import { Store } from '@ngrx/store';
 import { TopologySelectors } from '@service-bus-browser/topology-store';
 import { GenericTreeNodeComponent } from '../generic-tree-node/generic-tree-node.component';
@@ -32,6 +30,17 @@ import { ConfirmationService } from '@service-bus-browser/shared-components';
 import { TopologyActions } from '@service-bus-browser/topology-store';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { debounceTime, Subject } from 'rxjs';
+import { AutoComplete, AutoCompleteCompleteEvent, AutoCompleteSelectEvent } from 'primeng/autocomplete';
+import {
+  EMPTY_QUERY,
+  EXCLUDED_TAG_TYPES,
+  isQueryEmpty,
+  SearchChip,
+  SearchQuery,
+  serializeChip,
+  SuggestionGroup,
+  SuggestionItem,
+} from '../search/search-query.model';
 
 @Component({
   selector: 'sbb-tpl-topology-tree',
@@ -40,10 +49,9 @@ import { debounceTime, Subject } from 'rxjs';
     FormsModule,
     Tree,
     PrimeTemplate,
-    InputText,
-    Tooltip,
     GenericTreeNodeComponent,
     ReceiveMessagesDialog,
+    AutoComplete,
   ],
   templateUrl: './topology-tree.component.html',
   styleUrl: './topology-tree.component.scss',
@@ -86,20 +94,46 @@ export class TopologyTreeComponent {
     TopologySelectors.selectRootNodes,
   );
 
-  // Raw search term updated on every keystroke (drives the input binding)
-  searchTerm = signal('');
+  // ── Search query ──────────────────────────────────────────────────────────
 
-  // Debounced search term (~150 ms) used for actual filtering
-  private readonly searchTerm$ = new Subject<string>();
-  debouncedSearchTerm = toSignal(
-    this.searchTerm$.pipe(debounceTime(150)),
+  /** The full structured query (chips + free text). */
+  searchQuery = signal<SearchQuery>(EMPTY_QUERY);
+
+  /**
+   * The raw string currently in the AutoComplete text field (the part the user
+   * is typing right now, AFTER existing chips).  This drives the debounce and
+   * the suggestion list.
+   */
+  searchInputText = signal('');
+
+  // Debounced free-text term (~150 ms) — used for actual tree filtering
+  private readonly freeText$ = new Subject<string>();
+  debouncedFreeText = toSignal(
+    this.freeText$.pipe(debounceTime(150)),
     { initialValue: '' },
   );
 
+  /** The list of chips from the current query (convenience accessor for the template). */
+  currentChips = computed(() => this.searchQuery().chips);
+
+  /** True when any filtering is active (chips or free text). */
+  private searchActive = computed(() => !isQueryEmpty({
+    chips: this.searchQuery().chips,
+    freeText: this.debouncedFreeText(),
+  }));
+
+  // The autocomplete value binding — we only ever use the chip model internally;
+  // PrimeNG multiple mode needs the chip objects bound, so we bind currentChips.
+  // We use a fake ngModel value (not chips) since our chips are managed manually.
+  autocompleteValue = signal<SuggestionItem[]>([]);
+
+  // ── Suggestion state ──────────────────────────────────────────────────────
+
+  suggestions = signal<SuggestionGroup[]>([]);
+
   opened = signal<string[]>([]);
 
-  // Whether search is currently active (non-empty debounced term)
-  private searchActive = computed(() => this.debouncedSearchTerm().trim() !== '');
+  // ── Stage 1: selectability filter ────────────────────────────────────────
 
   // Selectability-filtered nodes (stage 1)
   private selectabilityFilteredNodes = computed<TopologyNode[]>(() => {
@@ -145,44 +179,75 @@ export class TopologyTreeComponent {
       .filter((node) => node !== null);
   });
 
+  // ── Stage 2: chip + free-text filter ─────────────────────────────────────
+
   treeNodes = computed<TreeNode<TopologyNode>[]>(() => {
-    const term = this.debouncedSearchTerm().trim().toLowerCase();
-    const isSearchActive = term !== '';
+    const chips = this.searchQuery().chips;
+    const term = this.debouncedFreeText().trim().toLowerCase();
+    const isFilterActive = chips.length > 0 || term !== '';
     const opened = this.opened();
 
-    if (!isSearchActive) {
-      // No search: render normally using user's opened state
+    if (!isFilterActive) {
       return this.selectabilityFilteredNodes().map((node) =>
         this.toTreeNode(node, false, opened),
       );
     }
 
-    // Search active: filter nodes, collect survivor paths, force-expand ancestors
     const matchedPaths = new Set<string>();
     const ancestorPaths = new Set<string>();
 
-    const nodeMatches = (node: TopologyNode): boolean =>
-      node.name.toLowerCase().includes(term);
+    /**
+     * A node is a PRIMARY MATCH when:
+     *  - For every chip c: the path root → node contains a node of type c.type
+     *    whose name equals c.value (exact, case-insensitive).
+     *  - AND (term empty) OR (node.name contains term, case-insensitive).
+     */
+    const nodeMatchesChips = (
+      node: TopologyNode,
+      ancestorPath: TopologyNode[],
+    ): boolean => {
+      if (chips.length === 0) return true;
+      const allNodes = [...ancestorPath, node];
+      return chips.every((chip) =>
+        allNodes.some(
+          (n) =>
+            n.type === chip.type &&
+            n.name.toLowerCase() === chip.value.toLowerCase(),
+        ),
+      );
+    };
 
-    // Determine which nodes survive the search
+    const nodeMatchesFreeText = (node: TopologyNode): boolean =>
+      term === '' || node.name.toLowerCase().includes(term);
+
+    const nodeIsPrimaryMatch = (
+      node: TopologyNode,
+      ancestorPath: TopologyNode[],
+    ): boolean =>
+      nodeMatchesChips(node, ancestorPath) && nodeMatchesFreeText(node);
+
     const collectSurvivors = (
       node: TopologyNode,
-      ancestors: string[],
+      ancestors: TopologyNode[],
+      ancestorPaths_: string[],
     ): boolean => {
-      const selfMatches = nodeMatches(node);
+      const selfMatches = nodeIsPrimaryMatch(node, ancestors);
 
-      // If self matches, add all ancestors and self; all descendants are visible (not filtered further)
       if (selfMatches) {
         matchedPaths.add(node.path);
-        for (const a of ancestors) ancestorPaths.add(a);
+        for (const a of ancestorPaths_) ancestorPaths.add(a);
         return true;
       }
 
-      // Check children
       let anyChildSurvives = false;
       if (node.children) {
         for (const child of node.children) {
-          if (collectSurvivors(child, [...ancestors, node.path])) {
+          if (
+            collectSurvivors(child, [...ancestors, node], [
+              ...ancestorPaths_,
+              node.path,
+            ])
+          ) {
             anyChildSurvives = true;
           }
         }
@@ -190,17 +255,17 @@ export class TopologyTreeComponent {
 
       if (anyChildSurvives) {
         ancestorPaths.add(node.path);
-        for (const a of ancestors) ancestorPaths.add(a);
+        for (const a of ancestorPaths_) ancestorPaths.add(a);
       }
 
       return anyChildSurvives;
     };
 
     for (const root of this.selectabilityFilteredNodes()) {
-      collectSurvivors(root, []);
+      collectSurvivors(root, [], []);
     }
 
-    // Build filtered tree: keep matched nodes (with full subtree) and ancestors
+    // Build filtered tree: keep matched nodes (full subtree) and ancestors
     const buildFilteredTree = (
       node: TopologyNode,
     ): TreeNode<TopologyNode> | null => {
@@ -211,7 +276,6 @@ export class TopologyTreeComponent {
         return null;
       }
 
-      // Self matches: show full subtree (no further filtering)
       if (selfMatches) {
         return this.toTreeNode(node, true, opened);
       }
@@ -224,7 +288,7 @@ export class TopologyTreeComponent {
       return {
         key: node.path,
         data: structuredClone(node),
-        expanded: true, // force-open ancestors
+        expanded: true,
         children: filteredChildren,
         leaf: filteredChildren.length === 0,
         selectable: node.selectable,
@@ -253,26 +317,185 @@ export class TopologyTreeComponent {
     return flatten(this.treeNodes());
   });
 
+  // ── Chip exact-match set (for highlight) ─────────────────────────────────
+
+  /**
+   * A set of `"type\0value"` strings for O(1) lookup in the tree template.
+   * (Using null byte as a delimiter that can never appear in type/value.)
+   */
+  chipMatchKeys = computed<Set<string>>(() => {
+    const keys = new Set<string>();
+    for (const chip of this.searchQuery().chips) {
+      keys.add(`${chip.type}\0${chip.value.toLowerCase()}`);
+    }
+    return keys;
+  });
+
   constructor() {
     this.store.dispatch(TopologyActions.loadTopologyRootNodes());
 
-    // Push search term changes into the debounce subject
+    // Push free-text changes into the debounce subject
     effect(() => {
-      const term = this.searchTerm();
-      untracked(() => this.searchTerm$.next(term));
+      const text = this.searchInputText();
+      untracked(() => this.freeText$.next(text));
     });
 
-    // Clear search term when topology root nodes identity changes (workspace switch)
+    // Clear search when topology root nodes identity changes (workspace switch)
     let previousRootNodes = this.topologyRootNodes();
     effect(() => {
       const rootNodes = this.topologyRootNodes();
       if (rootNodes !== previousRootNodes) {
         previousRootNodes = rootNodes;
-        untracked(() => this.searchTerm.set(''));
-        untracked(() => this.searchTerm$.next(''));
+        untracked(() => {
+          this.searchQuery.set(EMPTY_QUERY);
+          this.searchInputText.set('');
+          this.freeText$.next('');
+        });
       }
     });
   }
+
+  // ── Autosuggest ───────────────────────────────────────────────────────────
+
+  /**
+   * Called by PrimeNG AutoComplete on every keystroke.
+   * Builds a blended list of entity suggestions + a free-text row.
+   */
+  onComplete(event: AutoCompleteCompleteEvent) {
+    const typed = event.query.trim();
+    const chips = this.searchQuery().chips;
+
+    // Types that already have a chip — never offered again
+    const usedTypes = new Set(chips.map((c) => c.type));
+
+    // Collect entity suggestions, scoped by current chips
+    const grouped = new Map<string, string[]>(); // type → matching names
+
+    const walkForSuggestions = (
+      node: TopologyNode,
+      ancestorPath: TopologyNode[],
+    ) => {
+      if (EXCLUDED_TAG_TYPES.has(node.type)) {
+        // Still descend to find children
+        node.children?.forEach((c) =>
+          walkForSuggestions(c, [...ancestorPath, node]),
+        );
+        return;
+      }
+
+      if (!usedTypes.has(node.type)) {
+        // Check whether this node satisfies the current chips in its ancestor path
+        const allNodes = [...ancestorPath, node];
+        const satisfiesChips = chips.every((chip) =>
+          allNodes.some(
+            (n) =>
+              n.type === chip.type &&
+              n.name.toLowerCase() === chip.value.toLowerCase(),
+          ),
+        );
+
+        if (satisfiesChips) {
+          const nameLower = node.name.toLowerCase();
+          const typedLower = typed.toLowerCase();
+          if (typed === '' || nameLower.includes(typedLower)) {
+            const list = grouped.get(node.type) ?? [];
+            // Deduplicate by name within the type group
+            if (!list.includes(node.name)) {
+              list.push(node.name);
+              grouped.set(node.type, list);
+            }
+          }
+        }
+      }
+
+      node.children?.forEach((c) =>
+        walkForSuggestions(c, [...ancestorPath, node]),
+      );
+    };
+
+    this.selectabilityFilteredNodes().forEach((root) =>
+      walkForSuggestions(root, []),
+    );
+
+    const groups: SuggestionGroup[] = [];
+
+    for (const [type, names] of grouped) {
+      groups.push({
+        groupLabel: type,
+        items: names.map((name) => ({
+          kind: 'entity' as const,
+          type,
+          label: name,
+          groupLabel: type,
+        })),
+      });
+    }
+
+    // Always-present free-text row
+    const freeTextLabel = typed
+      ? `Search for "${typed}"`
+      : 'Type to search…';
+    groups.push({
+      groupLabel: 'free text',
+      items: [
+        {
+          kind: 'freeText' as const,
+          text: typed,
+          label: freeTextLabel,
+        },
+      ],
+    });
+
+    this.suggestions.set(groups);
+  }
+
+  /**
+   * Called when the user selects an item from the suggestion dropdown.
+   * Entity suggestions → create a chip; free-text row → set trailing free text.
+   *
+   * We use `onSelect` from the AutoComplete (not `(ngModelChange)`) so we can
+   * distinguish entity vs. free-text choices.
+   */
+  onSuggestionSelect(event: AutoCompleteSelectEvent) {
+    const item = event.value as SuggestionItem;
+
+    if (item.kind === 'entity') {
+      const newChip: SearchChip = { type: item.type, value: item.label };
+      this.searchQuery.update((q) => ({
+        chips: [...q.chips, newChip],
+        freeText: q.freeText,
+      }));
+      // Clear the text field after chip creation
+      this.searchInputText.set('');
+    } else {
+      // Free-text row
+      this.searchInputText.set(item.text);
+      this.searchQuery.update((q) => ({ ...q, freeText: item.text }));
+    }
+
+    // Reset the autocomplete's visible value back to empty so the field is clear
+    this.autocompleteValue.set([]);
+  }
+
+  /**
+   * Called when the user removes a chip via the AutoComplete's × button.
+   * We ignore the PrimeNG ngModel update and manage chips manually.
+   */
+  removeChip(chip: SearchChip) {
+    this.searchQuery.update((q) => ({
+      ...q,
+      chips: q.chips.filter(
+        (c) => !(c.type === chip.type && c.value === chip.value),
+      ),
+    }));
+  }
+
+  /** Serialize a chip for display in the chip token label. */
+  chipLabel(chip: SearchChip): string {
+    return serializeChip(chip);
+  }
+
+  // ── Tree helpers ──────────────────────────────────────────────────────────
 
   private toTreeNode(
     node: TopologyNode,
@@ -414,5 +637,15 @@ export class TopologyTreeComponent {
     }
 
     this.treeSelection.set(event);
+  }
+
+  /**
+   * Returns true if a tree node's data should be highlighted as an exact chip match.
+   * Used by the template to set [exactMatch] on GenericTreeNodeComponent.
+   */
+  protected isExactChipMatch(node: TopologyNode | undefined): boolean {
+    if (!node) return false;
+    const keys = this.chipMatchKeys();
+    return keys.has(`${node.type}\0${node.name.toLowerCase()}`);
   }
 }

--- a/libs/topology/components/src/lib/topology-tree/topology-tree.component.ts
+++ b/libs/topology/components/src/lib/topology-tree/topology-tree.component.ts
@@ -1,11 +1,13 @@
 import {
   Component,
   computed,
+  effect,
   inject,
   input,
   model,
   output,
   signal,
+  untracked,
 } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
@@ -28,6 +30,8 @@ import { ReceiveMessagesDialog } from '@servicebus-browser/messages-components';
 import { ActionManager } from '@service-bus-browser/actions-framework';
 import { ConfirmationService } from '@service-bus-browser/shared-components';
 import { TopologyActions } from '@service-bus-browser/topology-store';
+import { toSignal } from '@angular/core/rxjs-interop';
+import { debounceTime, Subject } from 'rxjs';
 
 @Component({
   selector: 'sbb-tpl-topology-tree',
@@ -81,13 +85,29 @@ export class TopologyTreeComponent {
   topologyRootNodes = this.store.selectSignal(
     TopologySelectors.selectRootNodes,
   );
-  treeNodes = computed<TreeNode<TopologyNode>[]>(() => {
+
+  // Raw search term updated on every keystroke (drives the input binding)
+  searchTerm = signal('');
+
+  // Debounced search term (~150 ms) used for actual filtering
+  private readonly searchTerm$ = new Subject<string>();
+  debouncedSearchTerm = toSignal(
+    this.searchTerm$.pipe(debounceTime(150)),
+    { initialValue: '' },
+  );
+
+  opened = signal<string[]>([]);
+
+  // Whether search is currently active (non-empty debounced term)
+  private searchActive = computed(() => this.debouncedSearchTerm().trim() !== '');
+
+  // Selectability-filtered nodes (stage 1)
+  private selectabilityFilteredNodes = computed<TopologyNode[]>(() => {
     const selectionMode = this.selectionMode();
     const isSelectable = (node: TopologyNode) => {
       if (selectionMode === 'send') {
         return node.sendEndpoint !== undefined;
       }
-
       return true;
     };
     const hasSelectableChildren = (node: TopologyNode): boolean => {
@@ -122,9 +142,105 @@ export class TopologyTreeComponent {
 
     return this.topologyRootNodes()
       .map(filter)
-      .filter((node) => node !== null)
-      .map((node) => this.toTreeNode(node));
+      .filter((node) => node !== null);
   });
+
+  treeNodes = computed<TreeNode<TopologyNode>[]>(() => {
+    const term = this.debouncedSearchTerm().trim().toLowerCase();
+    const isSearchActive = term !== '';
+    const opened = this.opened();
+
+    if (!isSearchActive) {
+      // No search: render normally using user's opened state
+      return this.selectabilityFilteredNodes().map((node) =>
+        this.toTreeNode(node, false, opened),
+      );
+    }
+
+    // Search active: filter nodes, collect survivor paths, force-expand ancestors
+    const matchedPaths = new Set<string>();
+    const ancestorPaths = new Set<string>();
+
+    const nodeMatches = (node: TopologyNode): boolean =>
+      node.name.toLowerCase().includes(term);
+
+    // Determine which nodes survive the search
+    const collectSurvivors = (
+      node: TopologyNode,
+      ancestors: string[],
+    ): boolean => {
+      const selfMatches = nodeMatches(node);
+
+      // If self matches, add all ancestors and self; all descendants are visible (not filtered further)
+      if (selfMatches) {
+        matchedPaths.add(node.path);
+        for (const a of ancestors) ancestorPaths.add(a);
+        return true;
+      }
+
+      // Check children
+      let anyChildSurvives = false;
+      if (node.children) {
+        for (const child of node.children) {
+          if (collectSurvivors(child, [...ancestors, node.path])) {
+            anyChildSurvives = true;
+          }
+        }
+      }
+
+      if (anyChildSurvives) {
+        ancestorPaths.add(node.path);
+        for (const a of ancestors) ancestorPaths.add(a);
+      }
+
+      return anyChildSurvives;
+    };
+
+    for (const root of this.selectabilityFilteredNodes()) {
+      collectSurvivors(root, []);
+    }
+
+    // Build filtered tree: keep matched nodes (with full subtree) and ancestors
+    const buildFilteredTree = (
+      node: TopologyNode,
+    ): TreeNode<TopologyNode> | null => {
+      const selfMatches = matchedPaths.has(node.path);
+      const isAncestor = ancestorPaths.has(node.path);
+
+      if (!selfMatches && !isAncestor) {
+        return null;
+      }
+
+      // Self matches: show full subtree (no further filtering)
+      if (selfMatches) {
+        return this.toTreeNode(node, true, opened);
+      }
+
+      // Ancestor: filter children, force expanded
+      const filteredChildren = (node.children ?? [])
+        .map(buildFilteredTree)
+        .filter((n): n is TreeNode<TopologyNode> => n !== null);
+
+      return {
+        key: node.path,
+        data: structuredClone(node),
+        expanded: true, // force-open ancestors
+        children: filteredChildren,
+        leaf: filteredChildren.length === 0,
+        selectable: node.selectable,
+      };
+    };
+
+    return this.selectabilityFilteredNodes()
+      .map(buildFilteredTree)
+      .filter((n): n is TreeNode<TopologyNode> => n !== null);
+  });
+
+  // Whether the current search has no results
+  hasNoResults = computed(
+    () => this.searchActive() && this.treeNodes().length === 0,
+  );
+
   flatTreeNodes = computed<TreeNode<TopologyNode>[]>(() => {
     const flatten = (
       nodes: TreeNode<TopologyNode>[],
@@ -137,14 +253,32 @@ export class TopologyTreeComponent {
     return flatten(this.treeNodes());
   });
 
-  searchTerm = signal('');
-  opened = signal<string[]>([]);
-
   constructor() {
     this.store.dispatch(TopologyActions.loadTopologyRootNodes());
+
+    // Push search term changes into the debounce subject
+    effect(() => {
+      const term = this.searchTerm();
+      untracked(() => this.searchTerm$.next(term));
+    });
+
+    // Clear search term when topology root nodes identity changes (workspace switch)
+    let previousRootNodes = this.topologyRootNodes();
+    effect(() => {
+      const rootNodes = this.topologyRootNodes();
+      if (rootNodes !== previousRootNodes) {
+        previousRootNodes = rootNodes;
+        untracked(() => this.searchTerm.set(''));
+        untracked(() => this.searchTerm$.next(''));
+      }
+    });
   }
 
-  private toTreeNode(node: TopologyNode): TreeNode<TopologyNode> {
+  private toTreeNode(
+    node: TopologyNode,
+    forceExpand = false,
+    opened: string[] = this.opened(),
+  ): TreeNode<TopologyNode> {
     const mapper = (
       node: TopologyNode,
       isRoot: boolean,
@@ -163,7 +297,7 @@ export class TopologyTreeComponent {
       return {
         key: node.path,
         data: structuredClone(node),
-        expanded: this.opened().includes(node.path),
+        expanded: forceExpand || opened.includes(node.path),
         children: children,
         leaf: children.length === 0,
         selectable: node.selectable,


### PR DESCRIPTION
## What & why

Rebuilds the topology navigator's search into a tag + free-text experience. Previously the search box (`searchTerm`) was wired up in the template but never actually filtered anything. This PR makes it work and adds autosuggested, chip-based filters.

The design was worked out up front and is recorded in the repo: see [`CONTEXT.md`](CONTEXT.md) (glossary: Topology, Search Tag, Free Text), [`docs/adr/0004`](docs/adr/0004-topology-search-chip-model.md) (chip model), and [`docs/adr/0005`](docs/adr/0005-vhost-dedicated-node-type.md) (vhost node type).

## What you get

- **Free-text filtering** — case-insensitive substring over node names; matched nodes keep their full subtree, ancestors are kept for context, matched substrings are highlighted. Composes (AND) with the existing send-mode selectability filter; auto-expands to reveal matches and restores your prior expansion on clear; debounced ~150ms; distinct "no results" state.
- **Chip-based tags** — exact, type-scoped filters created only by picking from a blended autosuggest dropdown (entities grouped by type). Tags combine by hierarchical narrowing (always AND, one chip per type); tag keys are derived at runtime from the loaded topology (structural `operational-grouping` nodes excluded).
- **`{type}:` accelerator** — typing e.g. `exchange:` / `eventhub:` switches the dropdown to value-only mode for that type (case-insensitive). Suggestions rank prefix-before-substring and the dropdown is capped at 10 items, shown only after 3 characters.
- **vhost gets a dedicated node type** so it's addressable as a `vhost:` tag (was previously indistinguishable from the Queues/Exchanges folders).
- Search also works inside the **endpoint-selector dialog**, where keys/values are restricted to the sendable subset; that instance is independent and resets per open.

## How it was built & verified

Implemented as 5 vertical slices, each verified by lint + tests and an independent review pass. New unit tests cover the query-model helpers (`flattenTypeKey`, `resolveAcceleratorType`, `rankByPrefix`, caps). `nx lint` + `nx test` pass for `topology-components` and `rabbitmq-backend-clients`.

## Reviewer notes

- The `[type: value]` bracket form is only written notation — the pill renders `type: value`, and nothing is serialized/persisted (chips aren't copyable).
- Two PrimeNG-specific fixes are included: clearing the field via backspace now resets the filter (PrimeNG emits `onClear` instead of `completeMethod` when emptied), and the dropdown no longer opens an empty panel on focus (`showEmptyMessage=false`).
- This is a frontend feature validated via lint/tests/code review — it has **not** been smoke-tested by driving the running app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Redesigned search interface using chip-based filters with autocomplete suggestions
  * Search term highlighting in topology tree results
  * Free-text substring search within chip-filtered scope
  * Dynamic search suggestions based on available entity types

* **Documentation**
  * Added glossary entries defining key search concepts
  * Added architecture decision records for search model and vhost categorization

<!-- end of auto-generated comment: release notes by coderabbit.ai -->